### PR TITLE
Add middleware support to polaris

### DIFF
--- a/PolarisCore/PolarisHelperScripts.cs
+++ b/PolarisCore/PolarisHelperScripts.cs
@@ -1,0 +1,10 @@
+namespace PolarisCore
+{
+    public class PolarisHelperScripts
+    {
+        public static string InitializeRequestAndResponseScript => @"
+            param($req, $res);
+            $global:Request = $req;
+            $global:Response = $res;";
+    }
+}

--- a/PolarisCore/PolarisMiddleware.cs
+++ b/PolarisCore/PolarisMiddleware.cs
@@ -1,0 +1,8 @@
+namespace PolarisCore
+{
+    public class PolarisMiddleware
+    {
+        public string Name { get; set; }
+        public string ScriptBlock {get; set; }
+    }
+}

--- a/PolarisCore/PolarisRequest.cs
+++ b/PolarisCore/PolarisRequest.cs
@@ -1,16 +1,28 @@
 using System;
 using System.Collections.Specialized;
+using System.IO;
 using System.Net;
 
 namespace PolarisCore
 {
     public class PolarisRequest
     {
-        public NameValueCollection QueryParameters;
+        public string[] AcceptTypes { get { return RawRequest.AcceptTypes; } }
+        public object Body { get; set; }
+        public string BodyString { get; set; }
+        public CookieCollection Cookies { get { return RawRequest.Cookies; } }
+        public NameValueCollection Headers { get { return RawRequest.Headers; } }
+        public string Method { get { return RawRequest.HttpMethod; } }
+        public NameValueCollection Query { get { return RawRequest.QueryString; } }
+        public Uri Url { get { return RawRequest.Url; } }
+        public string UserAgent { get { return RawRequest.UserAgent; } }
+
+        private HttpListenerRequest RawRequest;
 
         public PolarisRequest(HttpListenerRequest rawRequest)
         {
-            QueryParameters = rawRequest.QueryString;
+            RawRequest = rawRequest;
+            BodyString = new StreamReader(rawRequest.InputStream).ReadToEnd();
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -14,10 +14,7 @@ That being said, we do plan on continuing to experiment within this repository f
 ## Example
 
 ```PowerShell
-Import-Module –Name .\Polaris.psm1
-
 New-GetRoute -Path "/helloworld" -ScriptBlock {
-    param($request,$response);
     $response.Send('Hello World!');
 }
 

--- a/example/example.ps1
+++ b/example/example.ps1
@@ -8,13 +8,11 @@ Import-Module –Name ..\Polaris.psm1
 
 # Hello World passing in the Path, Method & ScriptBlock
 New-WebRoute -Path "/helloworld" -Method "GET" -ScriptBlock {
-    param($request,$response);
     $response.Send('Hello World');
 }
 
 # Query Parameters are supported
 New-WebRoute -Path "/hellome" -Method "GET" -ScriptBlock {
-    param($request,$response);
     if ($request.QueryParameters['name']) {
         $response.Send('Hello ' + $request.QueryParameters['name']);
     } else {
@@ -23,8 +21,6 @@ New-WebRoute -Path "/hellome" -Method "GET" -ScriptBlock {
 }
 
 $sbWow = {
-    param($request,$response);
-
     $json = @{
         wow = $true
     }
@@ -36,6 +32,15 @@ $sbWow = {
 # Supports helper functions for Get, Post, Put, Delete
 New-PostRoute -Path "/wow" -ScriptBlock $sbWow
 
+# Body Parameters are supported if you use the -UseJsonBodyParserMiddleware
+New-PostRoute -Path "/hello" -ScriptBlock {
+    if ($request.Body.Name) {
+        $response.Send('Hello ' + $request.Body.Name);
+    } else {
+        $response.Send('Hello World');
+    }
+}
+
 # Pass in script file
 New-WebRoute -Path "/example" -Method "GET" -ScriptPath .\script.ps1
 
@@ -43,7 +48,7 @@ New-WebRoute -Path "/example" -Method "GET" -ScriptPath .\script.ps1
 New-StaticRoute -FolderPath "./static" -RoutePath "/public"
 
 # Start the server
-$app = Start-Polaris -Port 8082 -MinRunspaces 1 -MaxRunspaces 5 # all params are optional
+$app = Start-Polaris -Port 8082 -MinRunspaces 1 -MaxRunspaces 5 -UseJsonBodyParserMiddleware -Verbose # all params are optional
 
 # Stop the server
 #Stop-Polaris

--- a/example/script.ps1
+++ b/example/script.ps1
@@ -1,2 +1,1 @@
-param($request, $response)
 $response.Send("example");

--- a/test/PolarisMiddleware.Tests.ps1
+++ b/test/PolarisMiddleware.Tests.ps1
@@ -17,7 +17,8 @@ $defaultMiddleware = {
 Describe "Test middleware creation/usage" {
     Context "Test -UseJsonBodyParserMiddleware flag" {
         It "Adds the middleware to the list of middlewares" {
-            $app.RouteMiddleware.Contains($JsonBodyParserMiddlerware.ToString()) | Should Be $true
+            $filtered = $app.RouteMiddleware | ? { $_.Name -eq "JsonBodyParser" }
+            $filtered.Count | Should Be 1
         }
         It "Can use the body parameters in route scripts" {
             New-PostRoute -Path "/hello" -ScriptBlock {
@@ -33,18 +34,20 @@ Describe "Test middleware creation/usage" {
         }
     }
     Context "Test adding a new middleware" {
-        It "Adds the middleware to the list of middleware" {
-            $app.RouteMiddleware.Contains($defaultMiddleware.ToString()) | Should Be $true
+        It "Adds the middleware to the list of middlewares" {
+            (Get-RouteMiddleware -Name TestMiddleware).Name | Should Be "TestMiddleware"
         }
         It "Manipulates the Request before the Route script gets it" {
             $body = @{ Name = 'Atlas' } | ConvertTo-Json
             (Invoke-RestMethod -Uri "http://localhost:$Port/hello" -Method POST -Body $body) | Should Be 'Hello Manipulated';
         }
         BeforeEach {
-            New-RouteMiddleware -ScriptBlock $defaultMiddleware
+            $app.RouteMiddleware.Count | Should Be 1;
+            New-RouteMiddleware -Name TestMiddleware -ScriptBlock $defaultMiddleware
         }
         AfterEach {
-            $app.RouteMiddleware.RemoveAt($app.RouteMiddleware.Count - 1)
+            Remove-RouteMiddleware -Name TestMiddleware
+            $app.RouteMiddleware.Count | Should Be 1;
         }
     }
     AfterAll {

--- a/test/PolarisMiddleware.Tests.ps1
+++ b/test/PolarisMiddleware.Tests.ps1
@@ -1,0 +1,53 @@
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.", ".")
+. "$here\$sut"
+
+$JsonBodyParserMiddlerware = {
+    if ($Request.BodyString -ne $null) {
+        $Request.Body = $Request.BodyString | ConvertFrom-Json
+    }
+}
+
+$defaultMiddleware = {
+    if ($Request.BodyString -ne $null) {
+        $Request.Body = '{"Name":"Manipulated"}' | ConvertFrom-Json
+    }
+}
+
+Describe "Test middleware creation/usage" {
+    Context "Test -UseJsonBodyParserMiddleware flag" {
+        It "Adds the middleware to the list of middlewares" {
+            $app.RouteMiddleware.Contains($JsonBodyParserMiddlerware.ToString()) | Should Be $true
+        }
+        It "Can use the body parameters in route scripts" {
+            New-PostRoute -Path "/hello" -ScriptBlock {
+                if ($request.Body.Name) {
+                    $response.Send('Hello ' + $request.Body.Name);
+                } else {
+                    $response.Send('Hello World');
+                }
+            }
+
+            $body = @{ Name = 'Atlas' } | ConvertTo-Json
+            (Invoke-RestMethod -Uri "http://localhost:$Port/hello" -Method POST -Body $body) | Should Be 'Hello Atlas';
+        }
+    }
+    Context "Test adding a new middleware" {
+        It "Adds the middleware to the list of middleware" {
+            $app.RouteMiddleware.Contains($defaultMiddleware.ToString()) | Should Be $true
+        }
+        It "Manipulates the Request before the Route script gets it" {
+            $body = @{ Name = 'Atlas' } | ConvertTo-Json
+            (Invoke-RestMethod -Uri "http://localhost:$Port/hello" -Method POST -Body $body) | Should Be 'Hello Manipulated';
+        }
+        BeforeEach {
+            New-RouteMiddleware -ScriptBlock $defaultMiddleware
+        }
+        AfterEach {
+            $app.RouteMiddleware.RemoveAt($app.RouteMiddleware.Count - 1)
+        }
+    }
+    AfterAll {
+        Stop-Polaris
+    }
+}

--- a/test/PolarisMiddleware.ps1
+++ b/test/PolarisMiddleware.ps1
@@ -1,6 +1,6 @@
 Import-Module ..\Polaris.psm1
 
-New-WebRoute -Path "/helloworld" -Method "GET" -ScriptBlock {
+New-WebRoute -Path /helloworld -Method GET -ScriptBlock {
     $Response.Send('Hello World');
 }
 

--- a/test/PolarisMiddleware.ps1
+++ b/test/PolarisMiddleware.ps1
@@ -1,0 +1,9 @@
+Import-Module ..\Polaris.psm1
+
+New-WebRoute -Path "/helloworld" -Method "GET" -ScriptBlock {
+    $Response.Send('Hello World');
+}
+
+$Port = Get-Random -Minimum 7000 -Maximum 7999
+
+$app = Start-Polaris -Port $Port -MinRunspaces 1 -MaxRunspaces 5 -UseJsonBodyParserMiddleware # all params are optional

--- a/test/PolarisRoute.Tests.ps1
+++ b/test/PolarisRoute.Tests.ps1
@@ -3,7 +3,6 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.", ".")
 . "$here\$sut"
 
 $defaultScriptBlock = {
-    param($request, $response)
     $response.Send("test script");
 }
 $defaultScriptPath = './test.ps1';

--- a/test/PolarisRoute.Tests.ps1
+++ b/test/PolarisRoute.Tests.ps1
@@ -118,6 +118,22 @@ Describe "Test route creation" {
         }
     }
 
+    Context "Using Get-WebRoute and Remove-WebRoute" {
+        It "Will get the object with the routes" {
+            (Get-WebRoute)["test"]["GET"] | Should Be $defaultScriptBlock.ToString()
+        }
+        It "will remove the routes" {
+            Remove-WebRoute -Path "/test" -Method "GET"
+            (Get-WebRoute).Count | Should Be 0
+        }
+        BeforeEach {
+            New-WebRoute -Path "/test" -Method "GET" -ScriptBlock $defaultScriptBlock
+        }
+        AfterEach {
+            $Global:Polaris = $null
+        }
+    }
+
     AfterEach {
         $Global:Polaris = $null
     }

--- a/test/PolarisServer.Tests.ps1
+++ b/test/PolarisServer.Tests.ps1
@@ -38,7 +38,7 @@ Describe "Test webserver use" {
         $result.StatusCode | Should Be 200
     }
 
-    It "test /example route" {
+    It "test /public/index.html static route" {
         $expectedHtml = `
 '<div>hello world</div>
 
@@ -49,5 +49,8 @@ Describe "Test webserver use" {
         $result = Invoke-WebRequest -Uri "http://localhost:$Port/public/index.html"
         $result.Content | Should Be $expectedHtml
         $result.StatusCode | Should Be 200
+    }
+    AfterAll {
+        Stop-Polaris
     }
 }

--- a/test/PolarisServer.ps1
+++ b/test/PolarisServer.ps1
@@ -1,46 +1,42 @@
-if(-not (Test-Path -Path "..\Polaris.psm1")) {
+if(-not (Test-Path -Path ..\Polaris.psm1)) {
     Write-Error -Message "Cannot find Polaris.psm1"
     return;
 }
 
 # Import Polaris
-Import-Module –Name ..\Polaris.psm1
+Import-Module -Name ..\Polaris.psm1
 
 # Hello World passing in the Path, Method & ScriptBlock
-New-WebRoute -Path "/helloworld" -Method "GET" -ScriptBlock {
-    param($request,$response);
-    $response.Send('Hello World');
+New-WebRoute -Path /helloworld -Method GET -ScriptBlock {
+    $Response.Send('Hello World');
 }
 
 # Hello World passing in the Path, Method & ScriptBlock
-New-WebRoute -Path "/hellome" -Method "GET" -ScriptBlock {
-    param($request,$response);
-    if ($request.QueryParameters['name']) {
-        $response.Send('Hello ' + $request.QueryParameters['name']);
+New-WebRoute -Path /hellome -Method GET -ScriptBlock {
+    if ($Request.Query['name']) {
+        $Response.Send('Hello ' + $Request.Query['name']);
     } else {
-        $response.Send('Hello World');
+        $Response.Send('Hello World');
     }
 }
 
 $sbWow = {
-    param($request,$response);
-
     $json = @{
         wow = $true
     }
 
     # .Json helper function that sets content type
-    $response.Json(($json | ConvertTo-Json));
+    $Response.Json(($json | ConvertTo-Json));
 }
 
 # Supports helper functions for Get, Post, Put, Delete
-New-PostRoute -Path "/wow" -ScriptBlock $sbWow
+New-PostRoute -Path /wow -ScriptBlock $sbWow
 
 # Pass in script file
-New-WebRoute -Path "/example" -Method "GET" -ScriptPath .\test.ps1
+New-WebRoute -Path /example -Method GET -ScriptPath .\test.ps1
 
 # Also support static serving of a directory
-New-StaticRoute -FolderPath "./static" -RoutePath "/public"
+New-StaticRoute -FolderPath ./static -RoutePath /public
 
 $Port = Get-Random -Minimum 8000 -Maximum 8999
 

--- a/test/test.ps1
+++ b/test/test.ps1
@@ -1,2 +1,1 @@
-param($request, $response)
 $response.Send("test file");


### PR DESCRIPTION
# Middleware Support in Polaris

This PR contains the code to enable middleware in Polaris - with it comes **BREAKING CHANGES**

## What is Middleware?

Middleware is a concept that's been around for quite some time. In web frameworks, middleware is code that is able to manipulate the request that comes in before it hits your route logic. For Polaris, middleware gets run AFTER a request comes in, but BEFORE your route script block is run - hence, MIDDLEware.

I'll go into an example but first I need to talk about an important **BREAKING CHANGE**.

## Breaking Changes

There are 2 major breaking changes.
* Route (and Middleware) scripts do not need the `param($request, $response)` line at the top of the script. These parameters are made global in the scope of the script and will exist without this param line. This means that **YOU MUST REMOVE THIS LINE WITH THESE CHANGES**. _Why?_ Because the global params are $Request and $Response. If you have `param($request, $response)`, that will take priority over the global params and what you will have instead is two null variables. **REMOVE THAT LINE**. It's much easier if you do. 😄 
* `$request.QueryParameters` has been renamed to `$request.Query` because "Parameters" is a very long word.

Ok. On to that example. Did you remove those param lines yet? Do it. Seriously.

## Example
A very important middleware for Polaris is a JSON body parser. This will take the stream of the HTTP body (which is a string representation of the JSON body) and convert it into a PowerShell object to allow us to interact with the body data. Let's write a middleware that does this.

Like our Route scripts, the middleware is also just a PowerShell script:

```powershell
New-RouteMiddleware - Name JsonBodyParser -ScriptBlock {
    if ($Request.BodyString -ne $null) {
        $Request.Body = $Request.BodyString | ConvertFrom-Json
    }
}
```

Now that $Request is made available globally, we can check if the raw body string exists. If it does, we can parse that string and store it in the $Request.Body.

Then, we're able to use this body in our Route scripts like so:
```powershell
New-PostRoute -Path "/hello" -ScriptBlock {
    if ($request.Body.Name) {
        $response.Send('Hello ' + $request.Body.Name);
    } else {
        $response.Send('Hello World');
    }
}
```

When you do an `Invoke-RestMethod` you get the expected result:
```powershell
PS > Invoke-RestMethod -Uri http://localhost:8080/hello -Method POST -Body '{"Name":"Atlas"}' -ContentType application/json
Hello Atlas
```

It's really simple to get started. You can add any number of middlewares - they will be run in the order that they are added to Polaris.

But of course, since a JSON Body parser will be used in a lot of situations, we have one built in. All you have to do is flip the switch.

When you're ready to start your server, add this flag and it will turn on that exact middleware code above:
```powershell
Start-Polaris -UseJsonBodyParserMiddleware
```

or use the helper cmdlet: `Use-JsonBodyParserMiddleware`

## Misc

This PR also includes helper cmdlets to: 

* delete middleware - `Remove-RouteMiddleware`
* delete routes - `Remove-WebRoute`
* get the route dictionary - `Get-WebRoute`
* get the middleware by name - `Get-RouteMiddleware`

That's all for now. We're really excited to see what you come up with - using middleware.

Tyler