### PR TITLE
remove redundant semicolons

### DIFF
--- a/Polaris.psm1
+++ b/Polaris.psm1
@@ -1,5 +1,5 @@
 Add-Type -Path "$PSScriptRoot/PolarisCore/bin/Debug/netstandard2.0/Polaris.dll"
-$global:Polaris = $null;
+$global:Polaris = $null
 
 ##############################
 #.SYNOPSIS
@@ -22,8 +22,8 @@ $global:Polaris = $null;
 #
 #.EXAMPLE
 # New-WebRoute -Path "/helloworld" -Method "GET" -ScriptBlock {
-#    param($request,$response);
-#    $response.Send('Hello World');
+#    param($request,$response)
+#    $response.Send('Hello World')
 # }
 #
 # New-WebRoute -Path "/helloworld" -Method "GET" -ScriptPath ./example.ps1
@@ -50,15 +50,15 @@ function New-WebRoute {
         [Parameter()]
         [string]
         $ScriptPath)
-    CreateNewPolarisIfNeeded;
+    CreateNewPolarisIfNeeded
     if ($ScriptPath -ne $null -and $ScriptPath -ne "") {
         if(-Not (Test-Path -Path $ScriptPath)) {
-            ThrowError -ExceptionName FileNotFoundException -ExceptionMessage "File does not exist at path $ScriptPath";
+            ThrowError -ExceptionName FileNotFoundException -ExceptionMessage "File does not exist at path $ScriptPath"
         }
 
-        $ScriptBlock = [ScriptBlock]::Create((Get-Content -Path $ScriptPath -Raw));
+        $ScriptBlock = [ScriptBlock]::Create((Get-Content -Path $ScriptPath -Raw))
     }
-    $global:Polaris.AddRoute($Path, $Method, $ScriptBlock.ToString());
+    $global:Polaris.AddRoute($Path, $Method, $ScriptBlock.ToString())
 }
 
 ##############################
@@ -88,25 +88,25 @@ function New-StaticRoute {
         [Parameter(Mandatory=$True, Position=1)]
         [string]
         $FolderPath)
-    CreateNewPolarisIfNeeded;
+    CreateNewPolarisIfNeeded
     if(-Not (Test-Path -Path $FolderPath)) {
-        ThrowError -ExceptionName FileNotFoundException -ExceptionMessage "Folder does not exist at path $FolderPath";
+        ThrowError -ExceptionName FileNotFoundException -ExceptionMessage "Folder does not exist at path $FolderPath"
     }
 
-    $allPaths = Get-ChildItem -Path $FolderPath -Recurse | ForEach-Object { $_.FullName };
-    $resolvedPath = (Resolve-Path -Path $FolderPath).Path;
+    $allPaths = Get-ChildItem -Path $FolderPath -Recurse | ForEach-Object { $_.FullName }
+    $resolvedPath = (Resolve-Path -Path $FolderPath).Path
 
 
     $allPaths | ForEach-Object {
     $scriptTemplate = @"
-param(`$request,`$response);
+param(`$request,`$response)
 `$bytes = Get-Content "$_" -Encoding Byte -ReadCount 0
-`$response.SetContentType(([PolarisCore.PolarisResponse]::GetContentType("$_")));
-`$response.ByteResponse = `$bytes;
+`$response.SetContentType(([PolarisCore.PolarisResponse]::GetContentType("$_")))
+`$response.ByteResponse = `$bytes
 "@
 
         New-GetRoute -Path "$($RoutePath.TrimEnd("/"))$($_.Substring($resolvedPath.Length).Replace('\','/'))" `
-            -ScriptBlock ([ScriptBlock]::Create($scriptTemplate));
+            -ScriptBlock ([ScriptBlock]::Create($scriptTemplate))
     }
 }
 
@@ -149,10 +149,10 @@ function Start-Polaris {
     if ($global:Polaris -eq $null) {
         ThrowError -ExceptionName NoRoutesDefinedException -ExceptionMessage 'You must have at least 1 route defined.'
     }
-    #Invoke-Command -AsJob $global:Polaris.Start($Port, $MinRunspaces, $MaxRunspaces);
+    #Invoke-Command -AsJob $global:Polaris.Start($Port, $MinRunspaces, $MaxRunspaces)
     #Start-Job -ScriptBlock { param($Polaris); $Polaris.Start(); } -ArgumentList $global:Polaris
-    $global:Polaris.Start($Port, $MinRunspaces, $MaxRunspaces);
-    return $global:Polaris;
+    $global:Polaris.Start($Port, $MinRunspaces, $MaxRunspaces)
+    return $global:Polaris
 }
 
 ##############################
@@ -177,7 +177,7 @@ function Stop-Polaris {
         [Parameter(Position=0)]
         [PolarisCore.Polaris]
         $ServerContext = $global:Polaris)
-    $ServerContext.Stop();
+    $ServerContext.Stop()
 }
 
 ##############################
@@ -202,8 +202,8 @@ function Stop-Polaris {
 #
 #.EXAMPLE
 # New-GetRoute -Path "/helloworld" -ScriptBlock {
-#    param($request,$response);
-#    $response.Send('Hello World');
+#    param($request,$response)
+#    $response.Send('Hello World')
 # }
 #
 # New-GetRoute -Path "/helloworld" -ScriptPath ./example.ps1
@@ -226,8 +226,8 @@ function New-GetRoute {
         [Parameter(ParameterSetName = "ScriptPath")]
         [string]
         $ScriptPath)
-    CreateNewPolarisIfNeeded;
-    New-WebRoute -Path $Path -Method "GET" -ScriptBlock $ScriptBlock -ScriptPath $ScriptPath;
+    CreateNewPolarisIfNeeded
+    New-WebRoute -Path $Path -Method "GET" -ScriptBlock $ScriptBlock -ScriptPath $ScriptPath
 }
 
 ##############################
@@ -248,8 +248,8 @@ function New-GetRoute {
 #
 #.EXAMPLE
 # New-PostRoute -Path "/helloworld" -ScriptBlock {
-#    param($request,$response);
-#    $response.Send('Hello World');
+#    param($request,$response)
+#    $response.Send('Hello World')
 # }
 #
 # New-PostRoute -Path "/helloworld" -ScriptPath ./example.ps1
@@ -272,8 +272,8 @@ function New-PostRoute {
         [Parameter(ParameterSetName = "ScriptPath")]
         [string]
         $ScriptPath)
-    CreateNewPolarisIfNeeded;
-    New-WebRoute -Path $Path -Method "POST" -ScriptBlock $ScriptBlock -ScriptPath $ScriptPath;
+    CreateNewPolarisIfNeeded
+    New-WebRoute -Path $Path -Method "POST" -ScriptBlock $ScriptBlock -ScriptPath $ScriptPath
 }
 
 ##############################
@@ -294,8 +294,8 @@ function New-PostRoute {
 #
 #.EXAMPLE
 # New-PutRoute -Path "/helloworld" -ScriptBlock {
-#    param($request,$response);
-#    $response.Send('Hello World');
+#    param($request,$response)
+#    $response.Send('Hello World')
 # }
 #
 # New-PutRoute -Path "/helloworld" -ScriptPath ./example.ps1
@@ -318,8 +318,8 @@ function New-PutRoute {
         [Parameter(ParameterSetName = "ScriptPath")]
         [string]
         $ScriptPath)
-    CreateNewPolarisIfNeeded;
-    New-WebRoute -Path $Path -Method "PUT" -ScriptBlock $ScriptBlock -ScriptPath $ScriptPath;
+    CreateNewPolarisIfNeeded
+    New-WebRoute -Path $Path -Method "PUT" -ScriptBlock $ScriptBlock -ScriptPath $ScriptPath
 }
 
 ##############################
@@ -340,8 +340,8 @@ function New-PutRoute {
 #
 #.EXAMPLE
 # New-DeleteRoute -Path "/helloworld" -ScriptBlock {
-#    param($request,$response);
-#    $response.Send('Hello World');
+#    param($request,$response)
+#    $response.Send('Hello World')
 # }
 #
 # New-DeleteRoute -Path "/helloworld" -ScriptPath ./example.ps1
@@ -364,8 +364,8 @@ function New-DeleteRoute {
         [Parameter(ParameterSetName = "ScriptPath")]
         [string]
         $ScriptPath)
-    CreateNewPolarisIfNeeded;
-    New-WebRoute -Path $Path -Method "DELETE" -ScriptBlock $ScriptBlock -ScriptPath $ScriptPath;
+    CreateNewPolarisIfNeeded
+    New-WebRoute -Path $Path -Method "DELETE" -ScriptBlock $ScriptBlock -ScriptPath $ScriptPath
 }
 
 ##############################
@@ -374,7 +374,7 @@ function New-DeleteRoute {
 function CreateNewPolarisIfNeeded () {
     if ($global:Polaris -eq $null) {
         [Action[string]]$logger = { param($str) Write-Verbose "$str" }
-        $global:Polaris = [PolarisCore.Polaris]::new($logger);
+        $global:Polaris = [PolarisCore.Polaris]::new($logger)
     }
 }
 

--- a/example/example.ps1
+++ b/example/example.ps1
@@ -1,6 +1,6 @@
 if(-not (Test-Path -Path "..\Polaris.psm1")) {
     Write-Error -Message "Cannot find Polaris.psm1"
-    return;
+    return
 }
 
 # Import Polaris
@@ -8,29 +8,29 @@ Import-Module –Name ..\Polaris.psm1
 
 # Hello World passing in the Path, Method & ScriptBlock
 New-WebRoute -Path "/helloworld" -Method "GET" -ScriptBlock {
-    param($request,$response);
-    $response.Send('Hello World');
+    param($request,$response)
+    $response.Send('Hello World')
 }
 
 # Query Parameters are supported
 New-WebRoute -Path "/hellome" -Method "GET" -ScriptBlock {
-    param($request,$response);
+    param($request,$response)
     if ($request.QueryParameters['name']) {
-        $response.Send('Hello ' + $request.QueryParameters['name']);
+        $response.Send('Hello ' + $request.QueryParameters['name'])
     } else {
-        $response.Send('Hello World');
+        $response.Send('Hello World')
     }
 }
 
 $sbWow = {
-    param($request,$response);
+    param($request,$response)
 
     $json = @{
         wow = $true
     }
 
     # .Json helper function that sets content type
-    $response.Json(($json | ConvertTo-Json));
+    $response.Json(($json | ConvertTo-Json))
 }
 
 # Supports helper functions for Get, Post, Put, Delete

--- a/example/script.ps1
+++ b/example/script.ps1
@@ -1,2 +1,2 @@
 param($request, $response)
-$response.Send("example");
+$response.Send("example")

--- a/test/PolarisServer.ps1
+++ b/test/PolarisServer.ps1
@@ -1,6 +1,6 @@
 if(-not (Test-Path -Path "..\Polaris.psm1")) {
     Write-Error -Message "Cannot find Polaris.psm1"
-    return;
+    return
 }
 
 # Import Polaris
@@ -8,29 +8,29 @@ Import-Module –Name ..\Polaris.psm1
 
 # Hello World passing in the Path, Method & ScriptBlock
 New-WebRoute -Path "/helloworld" -Method "GET" -ScriptBlock {
-    param($request,$response);
-    $response.Send('Hello World');
+    param($request,$response)
+    $response.Send('Hello World')
 }
 
 # Hello World passing in the Path, Method & ScriptBlock
 New-WebRoute -Path "/hellome" -Method "GET" -ScriptBlock {
-    param($request,$response);
+    param($request,$response)
     if ($request.QueryParameters['name']) {
-        $response.Send('Hello ' + $request.QueryParameters['name']);
+        $response.Send('Hello ' + $request.QueryParameters['name'])
     } else {
-        $response.Send('Hello World');
+        $response.Send('Hello World')
     }
 }
 
 $sbWow = {
-    param($request,$response);
+    param($request,$response)
 
     $json = @{
         wow = $true
     }
 
     # .Json helper function that sets content type
-    $response.Json(($json | ConvertTo-Json));
+    $response.Json(($json | ConvertTo-Json))
 }
 
 # Supports helper functions for Get, Post, Put, Delete

--- a/test/test.ps1
+++ b/test/test.ps1
@@ -1,2 +1,2 @@
 param($request, $response)
-$response.Send("test file");
+$response.Send("test file")


### PR DESCRIPTION
Semicolon is not required at the end of the lines in PowerShell
This is mostly a style guide thing but also it improves parsing speed by some small fraction.