### PR TITLE
Appveyor + Travis config updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 script:
   - pushd PolarisCore
   - dotnet restore
-  - dotnet build
+  - dotnet build -f netstandard2.0
   # Uncomment when Pester is supported in PowerShell for Linux
   # - popd && pushd test
   # - powershell -c 'Invoke-Pester -ExcludeTag VersionChecks -EnableExit'

--- a/Polaris.psm1
+++ b/Polaris.psm1
@@ -1,4 +1,4 @@
-Add-Type -Path "$PSScriptRoot/PolarisCore/bin/Debug/netstandard2.0/Polaris.dll"
+Add-Type -Path "$PSScriptRoot/PolarisCore/bin/Debug/net451/Polaris.dll"
 $global:Polaris = $null
 
 ##############################

--- a/Polaris.psm1
+++ b/Polaris.psm1
@@ -1,4 +1,8 @@
-Add-Type -Path "$PSScriptRoot/PolarisCore/bin/Debug/net451/Polaris.dll"
+if (Test-Path "$PSScriptRoot/PolarisCore/bin/Debug/net451/") {
+    Add-Type -Path "$PSScriptRoot/PolarisCore/bin/Debug/net451/Polaris.dll"
+} else {
+    Add-Type -Path "$PSScriptRoot/PolarisCore/bin/Debug/netstandard2.0/Polaris.dll"
+}
 $global:Polaris = $null
 
 ##############################

--- a/PolarisCore/Polaris.csproj
+++ b/PolarisCore/Polaris.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net451</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Management.Automation" Version="6.0.0-alpha17" />

--- a/PolarisCore/Polaris.csproj
+++ b/PolarisCore/Polaris.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net451</TargetFramework>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Management.Automation" Version="6.0.0-alpha17" />

--- a/PolarisCore/Polaris.csproj
+++ b/PolarisCore/Polaris.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Management.Automation" Version="6.0.0-alpha17" />

--- a/README.md
+++ b/README.md
@@ -29,11 +29,19 @@ Start-Polaris
 * [PowerShell Core 6](https://github.com/powershell/powershell)
 
 ### Steps
+#### Windows
 1. Clone or download the zip of the repo
 1. Open [PowerShell Core 6](https://github.com/powershell/powershell)
 1. run `cd Polaris/PolarisCore`
 1. run `dotnet restore`
 1. run `dotnet build`
+1. run `cd ..`
+#### Unix/Linux
+1. Clone or download the zip of the repo
+1. Open [PowerShell Core 6](https://github.com/powershell/powershell)
+1. run `cd Polaris/PolarisCore`
+1. run `dotnet restore`
+1. run `dotnet build -f netstandard2.0`
 1. run `cd ..`
 
 At this point, you can now run `Import-Module ./Polaris.psm1` to start using Polaris! Checkout [the wiki](https://github.com/PowerShell/Polaris/wiki) for more usage!

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ install:
 - ps: mkdir C:\temp
 - ps: (New-Object System.Net.WebClient).DownloadFile("https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.8/PowerShell-6.0.0-beta.8-win-x64.msi", "C:\temp\powershell6.msi")
 - C:\temp\powershell6.msi /quiet
-- pushd C:\projects\polaris\PowerShellCore
+- pushd C:\projects\polaris\PolarisCore
 - dotnet restore
 - dotnet build
 - popd

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,4 +26,4 @@ install:
 # If any of the tests fail, consider the pipeline failed
 test_script:
   - pushd C:\projects\polaris\test
-  - cmd: "C:\Program Files\PowerShell\\powershell.exe" -c '$res = Invoke-Pester -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru; (New-Object System.Net.WebClient).UploadFile(\"https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)\", (Resolve-Path .\TestsResults.xml)); if ($res.FailedCount -gt 0) { throw \"$($res.FailedCount) tests failed.\"}'
+  - cmd: "C:\\Program Files\\PowerShell\\powershell.exe" -c '$res = Invoke-Pester -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru; (New-Object System.Net.WebClient).UploadFile(\"https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)\", (Resolve-Path .\TestsResults.xml)); if ($res.FailedCount -gt 0) { throw \"$($res.FailedCount) tests failed.\"}'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,9 @@ skip_commits:
     - README.md
   message: /updated readme.*|update readme.*s|update docs.*|update version.*|update appveyor.*/
 
+branches:
+  only:
+    - master
 # There's no need to alter the build number for a Pull Request (PR) since they don't modify anything
 pull_requests:
   do_not_increment_build_number: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,4 +27,4 @@ install:
 test_script:
   - ps: |
         pushd C:\projects\polaris\build
-        "C:\Program Files\PowerShell\powershell.exe" -File appveyor.ps1
+        & 'C:\Program Files\PowerShell\powershell.exe' -File appveyor.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,4 +27,4 @@ install:
 test_script:
   - ps: |
         pushd C:\projects\polaris\build
-        "C:\Program Files\PowerShell\\powershell.exe" .\appveyor.ps1
+        "C:\Program Files\PowerShell\powershell.exe" appveyor.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,5 +25,5 @@ install:
 # Invoke Pester to run all of the unit tests, then save the results into XML in order to populate the AppVeyor tests section
 # If any of the tests fail, consider the pipeline failed
 test_script:
-  - pushd C:\projects\polaris\test
-  - cmd: "C:\\Program Files\\PowerShell\\powershell.exe" -c '$res = Invoke-Pester -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru; (New-Object System.Net.WebClient).UploadFile(\"https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)\", (Resolve-Path .\TestsResults.xml)); if ($res.FailedCount -gt 0) { throw \"$($res.FailedCount) tests failed.\"}'
+  - pushd C:\projects\polaris\build
+  - cmd: "C:\\Program Files\\PowerShell\\powershell.exe" .\appveyor.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,4 +27,4 @@ install:
 test_script:
   - ps: |
         pushd C:\projects\polaris\build
-        & 'C:\Program Files\PowerShell\powershell.exe' -File appveyor.ps1
+        & 'C:\Program Files\PowerShell\v6.0.0-beta.8\powershell.exe' -File appveyor.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,4 +27,4 @@ install:
 test_script:
   - ps: |
         pushd C:\projects\polaris\build
-        & 'C:\Program Files\PowerShell\6.0.0-beta.8\powershell.exe' -File appveyor.ps1
+        & 'C:\Program Files\PowerShell\6.0.0-beta.8\powershell.exe' -NonInteractive -NoProfile -File appveyor.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,4 +26,4 @@ install:
 # If any of the tests fail, consider the pipeline failed
 test_script:
   - pushd C:\projects\polaris\build
-  - cmd: "C:\\Program Files\\PowerShell\\powershell.exe" .\appveyor.ps1
+  - ps: "C:\Program Files\PowerShell\powershell.exe" .\appveyor.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ install:
 - C:\temp\powershell6.msi /quiet
 - pushd C:\projects\polaris\PolarisCore
 - dotnet restore
-- dotnet build
+- dotnet build -f net451
 # Invoke Pester to run all of the unit tests, then save the results into XML in order to populate the AppVeyor tests section
 # If any of the tests fail, consider the pipeline failed
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,4 +26,4 @@ install:
 # If any of the tests fail, consider the pipeline failed
 test_script:
   - pushd C:\projects\polaris\test
-  - %ProgramFiles%\PowerShell\powershell.exe -c '$res = Invoke-Pester -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru; (New-Object "System.Net.WebClient").UploadFile(\"https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)\", (Resolve-Path .\TestsResults.xml)); if ($res.FailedCount -gt 0) { throw \"$($res.FailedCount) tests failed.\"}'
+  - cmd: \%ProgramFiles%\PowerShell\powershell.exe -c '$res = Invoke-Pester -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru; (New-Object System.Net.WebClient).UploadFile(\"https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)\", (Resolve-Path .\TestsResults.xml)); if ($res.FailedCount -gt 0) { throw \"$($res.FailedCount) tests failed.\"}'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,4 @@ install:
 # If any of the tests fail, consider the pipeline failed
 test_script:
   - pushd C:\projects\polaris\test
-  - |
-    "$env:ProgramFiles\PowerShell\powershell.exe" -c '$res = Invoke-Pester -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru; `
-    (New-Object "System.Net.WebClient").UploadFile(\"https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)\", (Resolve-Path .\TestsResults.xml)); `
-    if ($res.FailedCount -gt 0) { throw \"$($res.FailedCount) tests failed.\"}'
+  - "$env:ProgramFiles\PowerShell\powershell.exe" -c '$res = Invoke-Pester -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru; (New-Object "System.Net.WebClient").UploadFile(\"https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)\", (Resolve-Path .\TestsResults.xml)); if ($res.FailedCount -gt 0) { throw \"$($res.FailedCount) tests failed.\"}'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,6 @@ install:
 - pushd C:\projects\polaris\PolarisCore
 - dotnet restore
 - dotnet build
-- popd
 # Invoke Pester to run all of the unit tests, then save the results into XML in order to populate the AppVeyor tests section
 # If any of the tests fail, consider the pipeline failed
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,4 +27,4 @@ install:
 test_script:
   - ps: |
         pushd C:\projects\polaris\build
-        & 'C:\Program Files\PowerShell\v6.0.0-beta.8\powershell.exe' -File appveyor.ps1
+        & 'C:\Program Files\PowerShell\6.0.0-beta.8\powershell.exe' -File appveyor.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,4 +26,4 @@ install:
 # If any of the tests fail, consider the pipeline failed
 test_script:
   - pushd C:\projects\polaris\test
-  - cmd: "C:\Program Files\PowerShell\powershell.exe" -c '$res = Invoke-Pester -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru; (New-Object System.Net.WebClient).UploadFile(\"https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)\", (Resolve-Path .\TestsResults.xml)); if ($res.FailedCount -gt 0) { throw \"$($res.FailedCount) tests failed.\"}'
+  - cmd: "C:\Program Files\PowerShell\\powershell.exe" -c '$res = Invoke-Pester -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru; (New-Object System.Net.WebClient).UploadFile(\"https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)\", (Resolve-Path .\TestsResults.xml)); if ($res.FailedCount -gt 0) { throw \"$($res.FailedCount) tests failed.\"}'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,4 +26,4 @@ install:
 # If any of the tests fail, consider the pipeline failed
 test_script:
   - pushd C:\projects\polaris\test
-  - cmd: 'C:\Program Files\PowerShell\powershell.exe' -c '$res = Invoke-Pester -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru; (New-Object System.Net.WebClient).UploadFile(\"https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)\", (Resolve-Path .\TestsResults.xml)); if ($res.FailedCount -gt 0) { throw \"$($res.FailedCount) tests failed.\"}'
+  - cmd: "C:\Program Files\PowerShell\powershell.exe" -c '$res = Invoke-Pester -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru; (New-Object System.Net.WebClient).UploadFile(\"https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)\", (Resolve-Path .\TestsResults.xml)); if ($res.FailedCount -gt 0) { throw \"$($res.FailedCount) tests failed.\"}'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,4 +26,4 @@ install:
 # If any of the tests fail, consider the pipeline failed
 test_script:
   - pushd C:\projects\polaris\test
-  - cmd: \%ProgramFiles%\PowerShell\powershell.exe -c '$res = Invoke-Pester -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru; (New-Object System.Net.WebClient).UploadFile(\"https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)\", (Resolve-Path .\TestsResults.xml)); if ($res.FailedCount -gt 0) { throw \"$($res.FailedCount) tests failed.\"}'
+  - cmd: C:\Program\ Files\PowerShell\powershell.exe -c '$res = Invoke-Pester -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru; (New-Object System.Net.WebClient).UploadFile(\"https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)\", (Resolve-Path .\TestsResults.xml)); if ($res.FailedCount -gt 0) { throw \"$($res.FailedCount) tests failed.\"}'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,4 +27,4 @@ install:
 test_script:
   - ps: |
         pushd C:\projects\polaris\build
-        "C:\Program Files\PowerShell\powershell.exe" appveyor.ps1
+        "C:\Program Files\PowerShell\powershell.exe" -File appveyor.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,4 +26,4 @@ install:
 # If any of the tests fail, consider the pipeline failed
 test_script:
   - pushd C:\projects\polaris\test
-  - "$env:ProgramFiles\PowerShell\powershell.exe" -c '$res = Invoke-Pester -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru; (New-Object "System.Net.WebClient").UploadFile(\"https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)\", (Resolve-Path .\TestsResults.xml)); if ($res.FailedCount -gt 0) { throw \"$($res.FailedCount) tests failed.\"}'
+  - ps: "$env:ProgramFiles\PowerShell\powershell.exe" -c '$res = Invoke-Pester -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru; (New-Object "System.Net.WebClient").UploadFile(\"https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)\", (Resolve-Path .\TestsResults.xml)); if ($res.FailedCount -gt 0) { throw \"$($res.FailedCount) tests failed.\"}'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,4 +26,4 @@ install:
 # If any of the tests fail, consider the pipeline failed
 test_script:
   - pushd C:\projects\polaris\test
-  - ps: "$env:ProgramFiles\PowerShell\powershell.exe" -c '$res = Invoke-Pester -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru; (New-Object "System.Net.WebClient").UploadFile(\"https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)\", (Resolve-Path .\TestsResults.xml)); if ($res.FailedCount -gt 0) { throw \"$($res.FailedCount) tests failed.\"}'
+  - "C:\Program Files\PowerShell\powershell.exe" -c '$res = Invoke-Pester -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru; (New-Object "System.Net.WebClient").UploadFile(\"https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)\", (Resolve-Path .\TestsResults.xml)); if ($res.FailedCount -gt 0) { throw \"$($res.FailedCount) tests failed.\"}'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,4 +27,4 @@ install:
 test_script:
   - ps: |
         pushd C:\projects\polaris\build
-        & 'C:\Program Files\PowerShell\6.0.0-beta.8\powershell.exe' -NonInteractive -NoProfile -File appveyor.ps1
+        & 'C:\Program Files\PowerShell\6.0.0-beta.8\powershell.exe' -File appveyor.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,31 @@
+# Version number
+version: 0.0.1.{build}
+
+# Ignore testing a commit if only the README.md file changed
+# Or if various strings are found in the commit message: updated readme, update readme, update docs, update version, update appveyor
+skip_commits:
+  files:
+    - README.md
+  message: /updated readme.*|update readme.*s|update docs.*|update version.*|update appveyor.*/
+
+# There's no need to alter the build number for a Pull Request (PR) since they don't modify anything
+pull_requests:
+  do_not_increment_build_number: true
+
+# Install NuGet to interact with the PowerShell Gallery
+install:
+- ps: (New-Object System.Net.WebClient).DownloadFile("https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.8/PowerShell-6.0.0-beta.8-win-x64.msi", "powershell6.msi")
+- ps: .\powershell6.msi /quiet
+- pushd PowerShellCore
+- dotnet restore
+- dotnet build
+- popd
+# Invoke Pester to run all of the unit tests, then save the results into XML in order to populate the AppVeyor tests section
+# If any of the tests fail, consider the pipeline failed
+test_script:
+  - ps: pushd test
+  - ps: |
+        $env:ProgramFiles\PowerShell\powershell.exe -c '$res = Invoke-Pester -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru; `
+        (New-Object "System.Net.WebClient").UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\TestsResults.xml)); `
+        if ($res.FailedCount -gt 0) { throw "$($res.FailedCount) tests failed."}'
+  - ps: popd

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,4 +26,4 @@ install:
 # If any of the tests fail, consider the pipeline failed
 test_script:
   - pushd C:\projects\polaris\test
-  - 'C:\Program Files\PowerShell\powershell.exe' -c '$res = Invoke-Pester -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru; (New-Object System.Net.WebClient).UploadFile(\"https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)\", (Resolve-Path .\TestsResults.xml)); if ($res.FailedCount -gt 0) { throw \"$($res.FailedCount) tests failed.\"}'
+  - cmd: 'C:\Program Files\PowerShell\powershell.exe' -c '$res = Invoke-Pester -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru; (New-Object System.Net.WebClient).UploadFile(\"https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)\", (Resolve-Path .\TestsResults.xml)); if ($res.FailedCount -gt 0) { throw \"$($res.FailedCount) tests failed.\"}'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ pull_requests:
 # Install NuGet to interact with the PowerShell Gallery
 install:
 - ps: (New-Object System.Net.WebClient).DownloadFile("https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.8/PowerShell-6.0.0-beta.8-win-x64.msi", "powershell6.msi")
-- ps: .\powershell6.msi /quiet
+- .\powershell6.msi /quiet
 - pushd PowerShellCore
 - dotnet restore
 - dotnet build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ install:
 test_script:
   - ps: pushd C:\projects\polaris\test
   - ps: |
-        $env:ProgramFiles\PowerShell\powershell.exe -c '$res = Invoke-Pester -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru; `
+        "$env:ProgramFiles\PowerShell\powershell.exe" -c '$res = Invoke-Pester -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru; `
         (New-Object "System.Net.WebClient").UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\TestsResults.xml)); `
         if ($res.FailedCount -gt 0) { throw "$($res.FailedCount) tests failed."}'
   - ps: popd

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,4 +26,4 @@ install:
 # If any of the tests fail, consider the pipeline failed
 test_script:
   - pushd C:\projects\polaris\test
-  - cmd: C:\Program\ Files\PowerShell\powershell.exe -c '$res = Invoke-Pester -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru; (New-Object System.Net.WebClient).UploadFile(\"https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)\", (Resolve-Path .\TestsResults.xml)); if ($res.FailedCount -gt 0) { throw \"$($res.FailedCount) tests failed.\"}'
+  - 'C:\Program Files\PowerShell\powershell.exe' -c '$res = Invoke-Pester -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru; (New-Object System.Net.WebClient).UploadFile(\"https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)\", (Resolve-Path .\TestsResults.xml)); if ($res.FailedCount -gt 0) { throw \"$($res.FailedCount) tests failed.\"}'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,5 +25,6 @@ install:
 # Invoke Pester to run all of the unit tests, then save the results into XML in order to populate the AppVeyor tests section
 # If any of the tests fail, consider the pipeline failed
 test_script:
-  - pushd C:\projects\polaris\build
-  - ps: "C:\Program Files\PowerShell\powershell.exe" .\appveyor.ps1
+  - ps: |
+        pushd C:\projects\polaris\build
+        "C:\Program Files\PowerShell\\powershell.exe" .\appveyor.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,8 @@ pull_requests:
 
 # Install NuGet to interact with the PowerShell Gallery
 install:
-- ps: (New-Object System.Net.WebClient).DownloadFile("https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.8/PowerShell-6.0.0-beta.8-win-x64.msi", "powershell6.msi")
-- .\powershell6.msi /quiet
+- ps: (New-Object System.Net.WebClient).DownloadFile("https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.8/PowerShell-6.0.0-beta.8-win-x64.msi", "C:\temp\powershell6.msi")
+- C:\temp\powershell6.msi /quiet
 - pushd PowerShellCore
 - dotnet restore
 - dotnet build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,14 +17,14 @@ install:
 - ps: mkdir C:\temp
 - ps: (New-Object System.Net.WebClient).DownloadFile("https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.8/PowerShell-6.0.0-beta.8-win-x64.msi", "C:\temp\powershell6.msi")
 - C:\temp\powershell6.msi /quiet
-- pushd PowerShellCore
+- pushd C:\projects\polaris\PowerShellCore
 - dotnet restore
 - dotnet build
 - popd
 # Invoke Pester to run all of the unit tests, then save the results into XML in order to populate the AppVeyor tests section
 # If any of the tests fail, consider the pipeline failed
 test_script:
-  - ps: pushd test
+  - ps: pushd C:\projects\polaris\test
   - ps: |
         $env:ProgramFiles\PowerShell\powershell.exe -c '$res = Invoke-Pester -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru; `
         (New-Object "System.Net.WebClient").UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\TestsResults.xml)); `

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+build: off
+
 # Version number
 version: 0.0.1.{build}
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,9 +25,8 @@ install:
 # Invoke Pester to run all of the unit tests, then save the results into XML in order to populate the AppVeyor tests section
 # If any of the tests fail, consider the pipeline failed
 test_script:
-  - ps: pushd C:\projects\polaris\test
-  - ps: |
-        "$env:ProgramFiles\PowerShell\powershell.exe" -c '$res = Invoke-Pester -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru; `
-        (New-Object "System.Net.WebClient").UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\TestsResults.xml)); `
-        if ($res.FailedCount -gt 0) { throw "$($res.FailedCount) tests failed."}'
-  - ps: popd
+  - pushd C:\projects\polaris\test
+  - |
+    "$env:ProgramFiles\PowerShell\powershell.exe" -c '$res = Invoke-Pester -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru; `
+    (New-Object "System.Net.WebClient").UploadFile(\"https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)\", (Resolve-Path .\TestsResults.xml)); `
+    if ($res.FailedCount -gt 0) { throw \"$($res.FailedCount) tests failed.\"}'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,4 +26,4 @@ install:
 # If any of the tests fail, consider the pipeline failed
 test_script:
   - pushd C:\projects\polaris\test
-  - "C:\Program Files\PowerShell\powershell.exe" -c '$res = Invoke-Pester -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru; (New-Object "System.Net.WebClient").UploadFile(\"https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)\", (Resolve-Path .\TestsResults.xml)); if ($res.FailedCount -gt 0) { throw \"$($res.FailedCount) tests failed.\"}'
+  - %ProgramFiles%\PowerShell\powershell.exe -c '$res = Invoke-Pester -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru; (New-Object "System.Net.WebClient").UploadFile(\"https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)\", (Resolve-Path .\TestsResults.xml)); if ($res.FailedCount -gt 0) { throw \"$($res.FailedCount) tests failed.\"}'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,4 +27,4 @@ install:
 test_script:
   - ps: |
         pushd C:\projects\polaris\build
-        & 'C:\Program Files\PowerShell\6.0.0-beta.8\powershell.exe' -File appveyor.ps1
+        . .\appveyor.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,7 @@ pull_requests:
 
 # Install NuGet to interact with the PowerShell Gallery
 install:
+- ps: mkdir C:\temp
 - ps: (New-Object System.Net.WebClient).DownloadFile("https://github.com/PowerShell/PowerShell/releases/download/v6.0.0-beta.8/PowerShell-6.0.0-beta.8-win-x64.msi", "C:\temp\powershell6.msi")
 - C:\temp\powershell6.msi /quiet
 - pushd PowerShellCore

--- a/build/appveyor.ps1
+++ b/build/appveyor.ps1
@@ -1,3 +1,4 @@
+Install-Module Pester
 $res = Invoke-Pester -Path ..\test -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru;
 (New-Object System.Net.WebClient).UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\TestsResults.xml));
 if ($res.FailedCount -gt 0) { throw "$($res.FailedCount) tests failed."}

--- a/build/appveyor.ps1
+++ b/build/appveyor.ps1
@@ -1,0 +1,3 @@
+$res = Invoke-Pester -Path ..\test -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru;
+(New-Object System.Net.WebClient).UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\TestsResults.xml));
+if ($res.FailedCount -gt 0) { throw "$($res.FailedCount) tests failed."}

--- a/build/appveyor.ps1
+++ b/build/appveyor.ps1
@@ -1,4 +1,6 @@
 Install-Module Pester
-$res = Invoke-Pester -Path ..\test -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru;
+pushd C:\projects\polaris\test
+$res = Invoke-Pester -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru;
 (New-Object System.Net.WebClient).UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\TestsResults.xml));
 if ($res.FailedCount -gt 0) { throw "$($res.FailedCount) tests failed."}
+popd


### PR DESCRIPTION
* Allows building of PolarisCore to net451
* fixes AppVeyor to run tests against 451 because of an open issue in PowerShell (https://github.com/PowerShell/PowerShell/issues/5205)
* updates readme for different steps on different platforms
