### PR TITLE
Windows PowerShell Support and InvokeBuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -298,3 +298,6 @@ __pycache__/
 *.dll
 
 # End of https://www.gitignore.io/api/csharp,powershell
+
+# Pester output
+test/TestsResults.xml

--- a/Polaris.build.ps1
+++ b/Polaris.build.ps1
@@ -1,0 +1,113 @@
+#Requires -Modules @{ModuleName="InvokeBuild";ModuleVersion="3.7.1"}
+
+$script:IsCIBuild = $env:APPVEYOR -ne $null
+$script:IsUnix = $PSVersionTable.PSEdition -and $PSVersionTable.PSEdition -eq "Core" -and !$IsWindows
+
+if ($PSVersionTable.PSEdition -ne "Core") {
+    Add-Type -Assembly System.IO.Compression.FileSystem
+}
+
+task SetupDotNet -Before Restore, Build, Clean, Test {
+
+    $requiredSdkVersion = "2.0.0"
+
+    $dotnetPath = "$PSScriptRoot/.dotnet"
+    $dotnetExePath = if ($script:IsUnix) { "$dotnetPath/dotnet" } else { "$dotnetPath/dotnet.exe" }
+    $originalDotNetExePath = $dotnetExePath
+
+    if (!(Test-Path $dotnetExePath)) {
+        $installedDotnet = Get-Command dotnet -ErrorAction Ignore
+        if ($installedDotnet) {
+            $dotnetExePath = $installedDotnet.Source
+        }
+        else {
+            $dotnetExePath = $null
+        }
+    }
+
+    # Make sure the dotnet we found is the right version
+    if ($dotnetExePath -and (& $dotnetExePath --version) -eq $requiredSdkVersion) {
+        $script:dotnetExe = $dotnetExePath
+    }
+    else {
+        # Clear the path so that we invoke installation
+        $script:dotnetExe = $null
+    }
+
+    if ($script:dotnetExe -eq $null) {
+
+        Write-Host "`n### Installing .NET CLI $requiredSdkVersion...`n" -ForegroundColor Green
+
+        # The install script is platform-specific
+        $installScriptExt = if ($script:IsUnix) { "sh" } else { "ps1" }
+
+        # Download the official installation script and run it
+        $installScriptPath = "$([System.IO.Path]::GetTempPath())dotnet-install.$installScriptExt"
+        Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.$installScriptExt" -OutFile $installScriptPath
+        $env:DOTNET_INSTALL_DIR = "$PSScriptRoot/.dotnet"
+
+        if (!$script:IsUnix) {
+            & $installScriptPath -Version $requiredSdkVersion -InstallDir "$env:DOTNET_INSTALL_DIR"
+        }
+        else {
+            & /bin/bash $installScriptPath -Version $requiredSdkVersion -InstallDir "$env:DOTNET_INSTALL_DIR"
+            $env:PATH = $dotnetExeDir + [System.IO.Path]::PathSeparator + $env:PATH
+        }
+
+        Write-Host "`n### Installation complete." -ForegroundColor Green
+        $script:dotnetExe = $originalDotnetExePath
+    }
+
+    # This variable is used internally by 'dotnet' to know where it's installed
+    $script:dotnetExe = Resolve-Path $script:dotnetExe
+    if (!$env:DOTNET_INSTALL_DIR)
+    {
+        $dotnetExeDir = [System.IO.Path]::GetDirectoryName($script:dotnetExe)
+        $env:PATH = $dotnetExeDir + [System.IO.Path]::PathSeparator + $env:PATH
+        $env:DOTNET_INSTALL_DIR = $dotnetExeDir
+    }
+
+    Write-Host "`n### Using dotnet v$requiredSDKVersion at path $script:dotnetExe`n" -ForegroundColor Green
+}
+
+function NeedsRestore($rootPath) {
+    # This checks to see if the number of folders under a given
+    # path (like "src" or "test") is greater than the number of
+    # obj\project.assets.json files found under that path, implying
+    # that those folders have not yet been restored.
+    $projectAssets = (Get-ChildItem "$rootPath\*\obj\project.assets.json")
+    return ($projectAssets -eq $null) -or ((Get-ChildItem $rootPath).Length -gt $projectAssets.Length)
+}
+
+task Restore -If { "Restore" -in $BuildTask -or (NeedsRestore(".\PolarisCore")) } -Before Clean, Build, Test {
+    exec { & $script:dotnetExe restore .\PolarisCore\Polaris.csproj }
+}
+
+task Clean {
+    exec { & $script:dotnetExe clean .\PolarisCore\Polaris.csproj }
+}
+
+task Build {
+    if (!$script:IsUnix) {
+        exec { & $script:dotnetExe build .\PolarisCore\Polaris.csproj -f net451 }
+        Write-Host "" # Newline
+    }
+
+    exec { & $script:dotnetExe build .\PolarisCore\Polaris.csproj -f netstandard2.0 }
+}
+
+task Test {
+    # TODO: Add tests
+    if ($PSVersionTable.PSEdition -ne "Core") {
+        Install-Module Pester -Force -Scope CurrentUser
+    }
+    cd .\test
+    $res = Invoke-Pester -OutputFormat NUnitXml -OutputFile TestsResults.xml -PassThru;
+    if ($env:APPVEYOR) {
+        (New-Object System.Net.WebClient).UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\TestsResults.xml));
+    }
+    if ($res.FailedCount -gt 0) { throw "$($res.FailedCount) tests failed."}
+}
+
+# The default task is to run the entire CI build
+task . Clean, Build, Test

--- a/Polaris.psm1
+++ b/Polaris.psm1
@@ -1,7 +1,7 @@
-if (Test-Path "$PSScriptRoot/PolarisCore/bin/Debug/net451/") {
-    Add-Type -Path "$PSScriptRoot/PolarisCore/bin/Debug/net451/Polaris.dll"
-} else {
+if ($PSVersionTable.PSEdition -eq "Core") {
     Add-Type -Path "$PSScriptRoot/PolarisCore/bin/Debug/netstandard2.0/Polaris.dll"
+} else {
+    Add-Type -Path "$PSScriptRoot/PolarisCore/bin/Debug/net451/Polaris.dll"
 }
 $global:Polaris = $null
 

--- a/Polaris.psm1
+++ b/Polaris.psm1
@@ -162,7 +162,11 @@ function New-StaticRoute {
 
     $allPaths | ForEach-Object {
     $scriptTemplate = @"
-`$bytes = Get-Content "$_" -Encoding Byte -ReadCount 0
+if(`$PSVersionTable.PSEdition -eq "Core") {
+    `$bytes = Get-Content "$_" -AsByteStream -ReadCount 0
+} else {
+    `$bytes = Get-Content "$_" -Encoding Byte -ReadCount 0
+}
 `$response.SetContentType(([PolarisCore.PolarisResponse]::GetContentType("$_")))
 `$response.ByteResponse = `$bytes
 "@

--- a/README.md
+++ b/README.md
@@ -34,20 +34,10 @@ Polaris' differentiation is that it is cross-platform and uses the .NET HttpList
 * [PowerShell Core 6](https://github.com/powershell/powershell)
 
 ### Steps
-#### Windows
 1. Clone or download the zip of the repo
 1. Open [PowerShell Core 6](https://github.com/powershell/powershell)
-1. run `cd Polaris/PolarisCore`
-1. run `dotnet restore`
-1. run `dotnet build`
-1. run `cd ..`
-#### Unix/Linux
-1. Clone or download the zip of the repo
-1. Open [PowerShell Core 6](https://github.com/powershell/powershell)
-1. run `cd Polaris/PolarisCore`
-1. run `dotnet restore`
-1. run `dotnet build -f netstandard2.0`
-1. run `cd ..`
+1. run `Install-Module InvokeBuild`
+1. run `Invoke-Build Build`
 
 At this point, you can now run `Import-Module ./Polaris.psm1` to start using Polaris! Checkout [the wiki](https://github.com/PowerShell/Polaris/wiki) for more usage!
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,8 +30,8 @@ install:
 # If any of the tests fail, consider the pipeline failed
 test_script:
   - ps: |
-        pushd C:\projects\polaris\build
-        . .\appveyor.ps1
+        Install-Module InvokeBuild
+        Invoke-Build
 
 notifications:
   - provider: Webhook


### PR DESCRIPTION
If you're resourceful enough, you'll notice that Polaris actually already supports Windows PowerShell. That's how we have a [working AppVeyor build that runs Pester tests](https://ci.appveyor.com/project/PowerShell/polaris/branch/master).

### That said, I'm saying now that Polaris supports Windows PowerShell.

Polaris targets .NET Standard 2.0 and .NET Framework 4.5.1. If your version of PowerShell can import a dll from one of these libraries, you should be good to go.

If we need to target an even older version of the .NET Framework, please open an issue and I will address it. FYI [HttpListener support Windows XP SP2 and up](https://msdn.microsoft.com/en-us/library/system.net.httplistener(v=vs.110).aspx#Anchor_6).

### InvokeBuild

In addition to support for Windows PowerShell, we've onboarded to [InvokeBuild](https://github.com/nightroman/Invoke-Build). I find it really easy to use and it helps when deciding what frameworks to build on what machines.

### Breaking change

This PR also includes a **breaking change**. PowerShell Core 6 beta 9 includes a [breaking change](https://github.com/PowerShell/PowerShell/pull/5080) to Get-Content that removes the `-Encoding byte` flag and replaces it with `-AsByteStream`. Polaris uses Get-Content for static routes. Since PowerShell Core 6 is still in beta, I'm only going to support the latest version of PowerShell Core 6. That said, **static routes will no longer work with PowerShell Core 6 beta 8 and lower**. Please move to PowerShell Core 6

Addressed:
https://github.com/PowerShell/Polaris/issues/57
https://github.com/PowerShell/Polaris/issues/11