### PR TITLE
New features! Get errors and information logs out of your running route scripts 🐛🗒️ 

### DIFF
--- a/Polaris.psm1
+++ b/Polaris.psm1
@@ -584,7 +584,11 @@ function CreateNewPolarisIfNeeded () {
 
 $JsonBodyParserMiddlerware = {
     if ($Request.BodyString -ne $null) {
-        $Request.Body = $Request.BodyString | ConvertFrom-Json
+        try {
+            $Request.Body = $Request.BodyString | ConvertFrom-Json
+        } catch {
+            Write-Verbose "Failed to convert body from json"
+        }
     }
 }
 

--- a/PolarisCore/Polaris.cs
+++ b/PolarisCore/Polaris.cs
@@ -193,6 +193,17 @@ namespace PolarisCore
                             Log(PowerShellInstance.InvocationStateInfo.Reason.ToString());
                             response.Send(PowerShellInstance.InvocationStateInfo.Reason.ToString());
                             response.SetStatusCode(500);
+                        } else if (PowerShellInstance.HadErrors)
+                        {
+                            var errorsBody = "";
+                            for (int i = 0; i < PowerShellInstance.Streams.Error.Count; i++)
+                            {
+                                errorsBody += "[ " + i + " ]:\n";
+                                errorsBody += PowerShellInstance.Streams.Error[i].Exception.ToString();
+                                errorsBody += PowerShellInstance.Streams.Error[i].InvocationInfo.PositionMessage + "\n\n";
+                            }
+                            response.Send(errorsBody);
+                            response.SetStatusCode(500);
                         }
                         Send(rawResponse, response);
                         PowerShellInstance.Dispose();

--- a/test/PolarisServer.Tests.ps1
+++ b/test/PolarisServer.Tests.ps1
@@ -78,12 +78,14 @@ Hello World"
 
     Context "Test starting and stopping of the server" {
         BeforeAll {
-            Stop-Polaris
-            Start-Polaris -Port $Port
-
-            $result = Invoke-WebRequest -Uri "http://localhost:$Port/helloworld"
-            $result.StatusCode | Should Be 200
-        } -Skip:$IsUnix
+            if (-not $IsUnix) {
+                Stop-Polaris
+                Start-Polaris -Port $Port
+    
+                $result = Invoke-WebRequest -Uri "http://localhost:$Port/helloworld"
+                $result.StatusCode | Should Be 200
+            }
+        }
 
         It "Can properly shut down the server" {
             Stop-Polaris

--- a/test/PolarisServer.Tests.ps1
+++ b/test/PolarisServer.Tests.ps1
@@ -52,6 +52,10 @@ Describe "Test webserver use" {
             $result.StatusCode | Should Be 200
         }
 
+        It "test /error route that returns 500" {
+            { Invoke-WebRequest -Uri "http://localhost:$Port/error" } | Should Throw
+        }
+
         AfterAll {
             Stop-Polaris
         }

--- a/test/PolarisServer.ps1
+++ b/test/PolarisServer.ps1
@@ -38,6 +38,12 @@ New-WebRoute -Path /example -Method GET -ScriptPath .\test.ps1
 # Also support static serving of a directory
 New-StaticRoute -FolderPath ./static -RoutePath /public
 
+New-PostRoute -Path /error -ScriptBlock {
+    $params = @{}
+    $request.body.psobject.properties | ForEach-Object { $params[$_.Name] = $_.Value }
+    $response.Send("this should not show up in response")
+}
+
 $Port = Get-Random -Minimum 8000 -Maximum 8999
 
 # Start the app

--- a/test/PolarisServer.ps1
+++ b/test/PolarisServer.ps1
@@ -8,6 +8,8 @@ Import-Module -Name ..\Polaris.psm1
 
 # Hello World passing in the Path, Method & ScriptBlock
 New-WebRoute -Path /helloworld -Method GET -ScriptBlock {
+    Write-Host "This is Write-Host"
+    Write-Information "This is Write-Information" -Tags Tag0
     $Response.Send('Hello World')
 }
 
@@ -40,6 +42,7 @@ New-StaticRoute -FolderPath ./static -RoutePath /public
 
 New-PostRoute -Path /error -ScriptBlock {
     $params = @{}
+    Write-Host "asdf"
     $request.body.psobject.properties | ForEach-Object { $params[$_.Name] = $_.Value }
     $response.Send("this should not show up in response")
 }


### PR DESCRIPTION
Two big features!

## Know what's failing
Wouldn't it be nice to know if your route scripts are failing and why they are failing? Now you can! Polaris will now return errors if your script fails. Here's an example:

```powershell
New-PostRoute -Path /error -ScriptBlock {
    $params = @{}
    
    # Notice we're not checking for Null
    $request.body.psobject.properties | ForEach-Object { $params[$_.Name] = $_.Value }
    $response.Send("this should not show up in response")
}

# Notice we're not passing in a body
Invoke-RestMethod http://localhost:8080/error -Method POST
```
```
Invoke-RestMethod :
[0]:
System.Management.Automation.RuntimeException: Index operation failed; the array index evaluated to null.
   at CallSite.Target(Closure , CallSite , Object , Object , Object )
   at System.Dynamic.UpdateDelegates.UpdateAndExecute3[T0,T1,T2,TRet](CallSite site, T0 arg0, T1 arg1, T2 arg2)
   at System.Management.Automation.Interpreter.DynamicInstruction`4.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)At line:4 char:58
+ ... .psobject.properties | ForEach-Object { $params[$_.Name] = $_.Value }
+                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

## Know what's being logged
Getting the errors back will certainly help, but what about logging? 

Polaris now supports adding the: `PolarisLogs=true` query parameter to get back the output of `Write-Host` and `Write-Information`. Check it out:

```powershell
New-WebRoute -Path /helloworld -Method GET -ScriptBlock {
    Write-Host "This is Write-Host"
    Write-Information "This is Write-Information" -Tags Tag0
    $Response.Send('Hello World')
}

# Notice the `PolarisLogs=true` query param
Invoke-RestMethod http://localhost:8080/helloworld?PolarisLogs=true
```
```
[PSHOST]This is Write-Host
[Tag0]This is Write-Information

Hello World
```

Notice you still get the actual response of the route at the bottom. This means that it also works with routes that throw errors. You'll get the detailed logs in addition to any errors your scripts throw.

We hope that this will help everyone debug their scripts!

Enjoy!