### PR TITLE
Rewrite Route and Middleware commands

### DIFF
--- a/Polaris.psd1
+++ b/Polaris.psd1
@@ -69,7 +69,21 @@ Copyright = '(c) tylerleonhardt. All rights reserved.'
 # NestedModules = @()
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = '*'
+FunctionsToExport = @(
+    'New-WebRoute'
+    'Remove-WebRoute'
+    'Get-WebRoute'
+    'New-GetRoute'
+    'New-PostRoute'
+    'New-PutRoute'
+    'New-DeleteRoute'
+    'New-StaticRoute'
+    'New-RouteMiddleware'
+    'Remove-RouteMiddleware'
+    'Get-RouteMiddleware'
+    'Use-JsonBodyParserMiddleware'
+    'Start-Polaris'
+    'Stop-Polaris' )
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = '*'

--- a/Polaris.psd1
+++ b/Polaris.psd1
@@ -69,7 +69,7 @@ Copyright = '(c) tylerleonhardt. All rights reserved.'
 # NestedModules = @()
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = @('New-WebRoute', 'New-GetRoute', 'New-PostRoute', 'New-PutRoute', 'New-DeleteRoute', 'Start-Polaris', 'New-StaticRoute', 'Stop-Polaris')
+FunctionsToExport = '*'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = '*'

--- a/Polaris.psm1
+++ b/Polaris.psm1
@@ -292,6 +292,12 @@ function New-StaticRoute
         [switch]
         $Force )
     
+    $ErrorAction = $PSBoundParameters["ErrorAction"]
+    If ( -not $ErrorAction )
+    {
+        $ErrorAction = $ErrorActionPreference
+    }
+    
     CreateNewPolarisIfNeeded
     
     if ( -not ( Test-Path -Path $FolderPath ) )
@@ -323,7 +329,7 @@ function New-StaticRoute
             `$response.ByteResponse = `$bytes
 "@ )
 
-        New-WebRoute -Path $StaticPath -Method GET -ScriptBlock $ScriptBlock -Force:$Force
+        New-WebRoute -Path $StaticPath -Method GET -ScriptBlock $ScriptBlock -Force:$Force -ErrorAction:$ErrorAction
     }
 }
 
@@ -805,13 +811,11 @@ function CreateNewPolarisIfNeeded ()
     }
 }
 
-$JsonBodyParserMiddlerware = {
-    if ($Request.BodyString -ne $null) {
-        try {
-            $Request.Body = $Request.BodyString | ConvertFrom-Json
-        } catch {
-            Write-Verbose "Failed to convert body from json"
-        }
+$JsonBodyParserMiddlerware =
+{
+    if ( $Request.BodyString -ne $Null )
+    {
+        $Request.Body = $Request.BodyString | ConvertFrom-Json
     }
 }
 

--- a/Polaris.psm1
+++ b/Polaris.psm1
@@ -11,43 +11,36 @@ $global:Polaris = $null
 # Handles the removal of the module
 $ExecutionContext.SessionState.Module.OnRemove =
 {
-    Stop-Polaris
-    Remove-Variable -Name Polaris -Scope global
+    If ( $global:Polaris )
+    {
+        Stop-Polaris -ErrorAction SilentlyContinue
+        Remove-Variable -Name Polaris -Scope global
+    }
 }.GetNewClosure()
 
 <#
 .SYNOPSIS
     Add web route.
-
 .DESCRIPTION
     Create web route for server to serve.
-
 .PARAMETER Path
     Path (path/route/endpoint) of the web route to to be serviced.
-
 .PARAMETER Method
     HTTP verb/method to be serviced.
     Valid values are GET, POST, PUT, and DELETE
-
 .PARAMETER ScriptBlock
     ScriptBlock that will be triggered when web route is called.
-
 .PARAMETER ScriptPath
     Full path and name of script that will be triggered when web route is called.
-
 .PARAMETER Force
     Use -Force to overwrite any existing web route for the same path and method.
-
 .EXAMPLE
     New-WebRoute -Path "helloworld" -Method "GET" -ScriptBlock { $response.Send( 'Hello World' ) }
-
     To view results:
     Start-Polaris
     Start-Process http://localhost:8080/helloworld
-
 .EXAMPLE
     New-WebRoute -Path "helloworld" -Method "GET" -ScriptPath D:\Scripts\Example.ps1
-
     To view results, assuming default port:
     Start-Polaris
     Start-Process http://localhost:8080/helloworld
@@ -132,46 +125,33 @@ function New-WebRoute
 <#
 .SYNOPSIS
     Removes the web route.
-
 .DESCRIPTION
     Removes the web route(s) matching the specified path(s) and method(s).
-
 .PARAMETER Path
     Path(s) of the route(s) to remove.
     Accepts multiple values and wildcards.
     Accepts pipeline input.
     Accepts pipeline input by property name.
     Defaults to all paths (*).
-
 .PARAMETER Method
     Method(s) of the route(s) to remove.
     Accepts pipeline input by property name.
     Accepts multiple values and wildcards.
     Defaults to all methods (*).
-
 .EXAMPLE
     Remove-WebRoute
-
     Removes all existing web routes.
-
 .EXAMPLE
     Remove-WebRoute -Path 'helloworld' -Method GET
-
     Removes the web route for method GET for path helloworld.
-
 .EXAMPLE
     Remove-WebRoute -Path 'sub1/sub2/*'
-
     Removes all web routes for all methods for paths starting with sub1/sub2/.
-
 .EXAMPLE
     Remove-WebRoute -Path 'sub1/sub2/*' -Method GET, POST
-
     Removes all web routes for GET and POST methods for paths starting with sub1/sub2/.
-
 .EXAMPLE
     Get-WebRoute -Method Delete | Remove-Method
-
     Removes all web routes for DELETE methods for all paths.
 #>
 function Remove-WebRoute
@@ -204,110 +184,97 @@ function Remove-WebRoute
 <#
 .SYNOPSIS
     Get web routes.
-
 .DESCRIPTION
     Get web routes filtered by Path and Method, as specified.
-
 .PARAMETER Path
     Path of the route(s) to get.
+    Accepts pipeline input.
+    Accepts pipeline input by property name.
     Accepts multiple values and wildcards.
     Defaults to all paths (*).
-
 .PARAMETER Method
     Method(s) of the route(s) to get.
+    Accepts pipeline input by property name.
     Accepts multiple values and wildcards.
     Defaults to all methods (*).
-
 .EXAMPLE
     Get-WebRoute
-
     Gets all web routes.
-
 .EXAMPLE
     Get-WebRoute -Path 'helloworld' -Method 'GET'
-
     Gets the web route for method GET for path helloworld.
-
 .EXAMPLE
     Get-WebRoute -Path 'sub1/sub2/*'
-
     Gets all web routes for all methods for paths starting with sub1/sub2/.
-
 .EXAMPLE
     Get-WebRoute -Path 'sub1/sub2/*' -Method GET, POST
-
     Gets all web routes for GET and POST methods for paths starting with sub1/sub2/.
-
 .EXAMPLE
     Get-WebRoute -Method Delete
-
     Gets all web routes for DELETE methods for all paths.
 #>
 function Get-WebRoute
 {
     [CmdletBinding()]
     param(
+        [Parameter( ValueFromPipeline = $True,
+                    ValueFromPipelineByPropertyName = $True )]
         [string[]]
         $Path = '*',
 
+        [Parameter( ValueFromPipelineByPropertyName = $True )]
         [string[]]
         $Method = '*' )
-
-    if ( $global:Polaris )
+    
+    process
     {
-        $WebRoutes = [System.Collections.ArrayList]@()
-
-        ForEach ( $Route in $global:Polaris.ScriptBlockRoutes.GetEnumerator() )
+        if ( $global:Polaris )
         {
-            ForEach ( $RouteMethod in $Route.Value.GetEnumerator() )
+            $WebRoutes = [System.Collections.ArrayList]@()
+
+            ForEach ( $Route in $global:Polaris.ScriptBlockRoutes.GetEnumerator() )
             {
-                $Null = $WebRoutes.Add( [pscustomobject]@{ Path = $Route.Key; Method = $RouteMethod.Key; Scriptblock = $RouteMethod.Value } )
+                ForEach ( $RouteMethod in $Route.Value.GetEnumerator() )
+                {
+                    $Null = $WebRoutes.Add( [pscustomobject]@{ Path = $Route.Key; Method = $RouteMethod.Key; Scriptblock = $RouteMethod.Value } )
+                }
             }
+
+            $Filter = [scriptblock]::Create( (
+                '( ' + 
+                ( $Path.ForEach({   "`$_.Path   -like `"$_`"" } ) -join ' -or ' ) + 
+                ' ) -and ( ' +
+                ( $Method.ForEach({ "`$_.Method -like `"$_`"" } ) -join ' -or ' ) +
+                ' )' ) )
+
+            $WebRoutes = $WebRoutes.Where( $Filter )
+
+            return $WebRoutes
         }
-
-        $Filter = [scriptblock]::Create( (
-            '( ' + 
-            ( $Path.ForEach({   "`$_.Path   -like `"$_`"" } ) -join ' -or ' ) + 
-            ' ) -and ( ' +
-            ( $Method.ForEach({ "`$_.Method -like `"$_`"" } ) -join ' -or ' ) +
-            ' )' ) )
-
-        $WebRoutes = $WebRoutes.Where( $Filter )
-
-        return $WebRoutes
     }
 }
 
 <#
 .SYNOPSIS
     Creates web routes to recursively serve folder contents
-
 .DESCRIPTION
     Creates web routes to recursively serve folder contents. Perfect for static websites.
-
 .PARAMETER RoutePath
     Root route that the folder path will be served to.
     Defaults to "/".
-
 .PARAMETER FolderPath
     Full path and name of the folder to serve.
-
 .PARAMETER Force
     Use -Force to overwrite existing web route(s) for the same paths.
-
 .EXAMPLE
     New-StaticRoute -RoutePath 'public' -Path D:\FolderShares\public
-
     Creates web routes for GET method for each file recursively within D:\FolderShares\public
     at relative path /public, for example, http://localhost:8080/public/File1.html
-
 .EXAMPLE
     Get-WebRoute -Path 'public/*' -Method GET | Remove-WebRoute
     New-StaticRoute -RoutePath 'public' -Path D:\FolderShares\public
-
     Updates website web routes. (Deletes all existing web routes and creates new web routes
     for all existing folder content.)
-
 .NOTES
     Folders are not browsable. New files are not added dynamically.
 #>
@@ -332,7 +299,7 @@ function New-StaticRoute
         ThrowError -ExceptionName FileNotFoundException -ExceptionMessage "Folder does not exist at path $FolderPath"
     }
 
-    $allPaths = Get-ChildItem -Path $FolderPath -Recurse | ForEach-Object { $_.FullName }
+    $allPaths = Get-ChildItem -Path $FolderPath -Recurse -File | ForEach-Object { $_.FullName }
     $resolvedPath = ( Resolve-Path -Path $FolderPath ).Path
 
     $RoutePath = $RoutePath.TrimEnd( '/' )
@@ -363,23 +330,17 @@ function New-StaticRoute
 <#
 .SYNOPSIS
     Add new route middleware.
-
 .DESCRIPTION
     Creates new route middleware. Route middleware scripts are used to
     manipulate request and response objects and run before web route scripts.
-
 .PARAMETER Name
     Name of the middleware.
-
 .PARAMETER ScriptBlock
     ScriptBlock to run when middleware is triggered.
-
 .PARAMETER ScriptPath
     Full path and name to script to run when middleware is triggered.
-
 .PARAMETER Force
     Use -Force to overwrite any existing middleware with the same name.
-
 .EXAMPLE
 $JsonBodyParserMiddlerware =
 {
@@ -459,33 +420,24 @@ function New-RouteMiddleware
 <#
 .SYNOPSIS
     Remove route middleware.
-
 .DESCRIPTION
     Remove route middleware matching the specified name(s).
-
 .PARAMETER Name
     Name of the middleware to remove.
     Accepts multiple values and wildcards.
     Accepts pipeline input.
     Accepts pipeline input by property name.
     Defaults to all names (*).
-
 .EXAMPLE
     Remove-RouteMiddleware -Name JsonBodyParser
-
 .EXAMPLE
     Remove-RouteMiddleware
-
     Removes all route middleware.
-
 .EXAMPLE
     Remove-RouteMiddleware -Name ParamCheck*, ParamVerify*
-
     Removes any route middleware with names starting with ParamCheck or ParamVerify.
-
 .EXAMPLE
     Get-RouteMiddelware | Remove-RouteMiddleware
-
     Removes all reoute middleware.
 #>
 function Remove-RouteMiddleware
@@ -514,21 +466,18 @@ function Remove-RouteMiddleware
 <#
 .SYNOPSIS
     Get route middleware.
-
 .DESCRIPTION
     Get route middleware matching the specified name(s).
-
 .PARAMETER Name
     Name of the middleware to get.
+    Accepts pipeline input.
+    Accepts pipeline input by property name.
     Accepts multiple values and wildcards.
     Defaults to all names (*).
-
 .EXAMPLE
     Get-RouteMiddleware
-
 .EXAMPLE
     Get-RouteMiddleware -Name JsonBodyParser
-
 .EXAMPLE
     Get-RouteMiddleware -Name ParamCheck*, ParamVerify*
 #>
@@ -536,42 +485,40 @@ function Get-RouteMiddleware
 {
     [CmdletBinding()]
     param(
+        [Parameter( ValueFromPipeline = $True,
+                    ValueFromPipelineByPropertyName = $True )]
         [string[]]
         $Name = '*' )
 
-    if ( $global:Polaris )
+    process
     {
-        $Filter = [scriptblock]::Create( ( $Name.ForEach({ "`$_.Name   -like `"$_`"" }) -join ' -or ' ) )
+        if ( $global:Polaris )
+        {
+            $Filter = [scriptblock]::Create( ( $Name.ForEach({ "`$_.Name   -like `"$_`"" }) -join ' -or ' ) )
 
-        return $global:Polaris.RouteMiddleware.Where( $Filter )
+            return $global:Polaris.RouteMiddleware.Where( $Filter )
+        }
     }
 }
 
 <#
 .SYNOPSIS
     Start Polaris web server.
-
 .DESCRIPTION
     Start Polaris web server.
-
 .PARAMETER Port
     Port number to listen on.
     Defaults to 8080.
-
 .PARAMETER MinRunspaces
     Minimum number of PowerShell runspaces for web server to use.
     Defaults to 1.
-
 .PARAMETER MaxRunspaces
     Maximum number of PowerShell runspaces for web server to use.
     Defaults to 1.
-
 .PARAMETER UseJsonBodyParserMiddleware
     When present, JSONBodyParser middleware will be created, if needed.
-
 .EXAMPLE
     Start-Polaris
-
 .EXAMPLE
     Start-Polaris -Port 8081 -MinRunspaces 2 -MaxRunspaces 10 -UseJsonBodyParserMiddleware
 #>
@@ -605,17 +552,13 @@ function Start-Polaris {
 <#
 .SYNOPSIS
     Stop Polaris web server.
-
 .DESCRIPTION
     Stop Polaris web server.
-
 .PARAMETER ServerContext
     Polaris instance to stop.
     Defaults to the global instance.
-
 .EXAMPLE
     Stop-Polaris
-
 .EXAMPLE
     Stop-Polaris -ServerContext $app
 #>
@@ -639,32 +582,23 @@ function Stop-Polaris
 <#
 .SYNOPSIS
     Add web route with method GET
-
 .DESCRIPTION
     Wrapper for New-WebRoute -Method GET
-
 .PARAMETER Path
     Path (path/route/endpoint) of the web route to to be serviced.
-
 .PARAMETER ScriptBlock
     ScriptBlock that will be triggered when web route is called.
-
 .PARAMETER ScriptPath
     Full path and name of script that will be triggered when web route is called.
-
 .PARAMETER Force
     Use -Force to overwrite any existing web route for the same path and method.
-
 .EXAMPLE
     New-GetRoute -Path "helloworld" -ScriptBlock { $response.Send( 'Hello World' ) }
-
     To view results:
     Start-Polaris
     Start-Process http://localhost:8080/helloworld
-
 .EXAMPLE
     New-GetRoute -Path "helloworld" -ScriptPath D:\Scripts\Example.ps1
-
     To view results, assuming default port:
     Start-Polaris
     Start-Process http://localhost:8080/helloworld
@@ -698,32 +632,23 @@ function New-GetRoute
 <#
 .SYNOPSIS
     Add web route with method POST
-
 .DESCRIPTION
     Wrapper for New-WebRoute -Method POST
-
 .PARAMETER Path
     Path (path/route/endpoint) of the web route to to be serviced.
-
 .PARAMETER ScriptBlock
     ScriptBlock that will be triggered when web route is called.
-
 .PARAMETER ScriptPath
     Full path and name of script that will be triggered when web route is called.
-
 .PARAMETER Force
     Use -Force to overwrite any existing web route for the same path and method.
-
 .EXAMPLE
     New-GetRoute -Path "helloworld" -ScriptBlock { $response.Send( 'Hello World' ) }
-
     To view results, assuming default port:
     Start-Polaris
     Invoke-WebRequest -Uri http://localhost:8080/helloworld -Method POST
-
 .EXAMPLE
     New-GetRoute -Path "helloworld" -ScriptPath D:\Scripts\Example.ps1
-
     To view results, assuming default port:
     Start-Polaris
     Invoke-WebRequest -Uri http://localhost:8080/helloworld -Method POST
@@ -750,39 +675,30 @@ function New-PostRoute
     switch ( $PSCmdlet.ParameterSetName )
     {
         'ScriptBlock' { New-WebRoute -Path $Path -Method "POST" -ScriptBlock $ScriptBlock -Force:$Force }
-        'ScriptPath'  { New-WebRoute -Path $Path -Method "PSOT" -ScriptPath  $ScriptPath  -Force:$Force }
+        'ScriptPath'  { New-WebRoute -Path $Path -Method "POST" -ScriptPath  $ScriptPath  -Force:$Force }
     }
 }
 
 <#
 .SYNOPSIS
     Add web route with method PUT
-
 .DESCRIPTION
     Wrapper for New-WebRoute -Method PUT
-
 .PARAMETER Path
     Path (path/route/endpoint) of the web route to to be serviced.
-
 .PARAMETER ScriptBlock
     ScriptBlock that will be triggered when web route is called.
-
 .PARAMETER ScriptPath
     Full path and name of script that will be triggered when web route is called.
-
 .PARAMETER Force
     Use -Force to overwrite any existing web route for the same path and method.
-
 .EXAMPLE
     New-GetRoute -Path "helloworld" -ScriptBlock { $response.Send( 'Hello World' ) }
-
     To view results, assuming default port:
     Start-Polaris
     Invoke-WebRequest -Uri http://localhost:8080/helloworld -Method PUT
-
 .EXAMPLE
     New-GetRoute -Path "helloworld" -ScriptPath D:\Scripts\Example.ps1
-
     To view results, assuming default port:
     Start-Polaris
     Invoke-WebRequest -Uri http://localhost:8080/helloworld -Method PUT
@@ -815,32 +731,23 @@ function New-PutRoute {
 <#
 .SYNOPSIS
     Add web route with method DELETE
-
 .DESCRIPTION
     Wrapper for New-WebRoute -Method DELETE
-
 .PARAMETER Path
     Path (path/route/endpoint) of the web route to to be serviced.
-
 .PARAMETER ScriptBlock
     ScriptBlock that will be triggered when web route is called.
-
 .PARAMETER ScriptPath
     Full path and name of script that will be triggered when web route is called.
-
 .PARAMETER Force
     Use -Force to overwrite any existing web route for the same path and method.
-
 .EXAMPLE
     New-GetRoute -Path "helloworld" -ScriptBlock { $response.Send( 'Hello World' ) }
-
     To view results, assuming default port:
     Start-Polaris
     Invoke-WebRequest -Uri http://localhost:8080/helloworld -Method DELETE
-
 .EXAMPLE
     New-GetRoute -Path "helloworld" -ScriptPath D:\Scripts\Example.ps1
-
     To view results, assuming default port:
     Start-Polaris
     Invoke-WebRequest -Uri http://localhost:8080/helloworld -Method DELETE
@@ -873,10 +780,8 @@ function New-DeleteRoute {
 <#
 .SYNOPSIS
     Helper function that turns on the Json Body parsing middleware.
-
 .DESCRIPTION
     Helper function that turns on the Json Body parsing middleware.
-
 .EXAMPLE
     Use-JsonBodyParserMiddleware
 #>

--- a/Polaris.psm1
+++ b/Polaris.psm1
@@ -1,375 +1,634 @@
-if ($PSVersionTable.PSEdition -eq "Core") {
+if ($PSVersionTable.PSEdition -eq "Core")
+{
     Add-Type -Path "$PSScriptRoot/PolarisCore/bin/Debug/netstandard2.0/Polaris.dll"
-} else {
+}
+else
+{
     Add-Type -Path "$PSScriptRoot/PolarisCore/bin/Debug/net451/Polaris.dll"
 }
 $global:Polaris = $null
 
 # Handles the removal of the module
-$m = $ExecutionContext.SessionState.Module
-$m.OnRemove = {
+$ExecutionContext.SessionState.Module.OnRemove =
+{
     Stop-Polaris
     Remove-Variable -Name Polaris -Scope global
 }.GetNewClosure()
 
-##############################
-#.SYNOPSIS
-# Adds a new HTTP Route
-#
-#.DESCRIPTION
-# This cmdlet defines an HTTP route that your server will listen for
-#
-#.PARAMETER Path
-# The HTTP Route/Path/endpoint that you call to trigger this script
-#
-#.PARAMETER Method
-# The HTTP Verb/Method for this request
-#
-#.PARAMETER ScriptBlock
-# A script block that will be triggered when this HTTP Route/Path/endpoint has been called
-#
-#.PARAMETER ScriptPath
-# A path to a script that will be triggered when this HTTP Route/Path/endpoint has been called
-#
-#.EXAMPLE
-# New-WebRoute -Path "/helloworld" -Method "GET" -ScriptBlock {
-#    $response.Send('Hello World')
-# }
-#
-# New-WebRoute -Path "/helloworld" -Method "GET" -ScriptPath ./example.ps1
-#
-#.NOTES
-# Navigating to localhost:8080/helloworld would display the example.
-#
-##############################
-function New-WebRoute {
+<#
+.SYNOPSIS
+    Add web route.
+
+.DESCRIPTION
+    Create web route for server to serve.
+
+.PARAMETER Path
+    Path (path/route/endpoint) of the web route to to be serviced.
+
+.PARAMETER Method
+    HTTP verb/method to be serviced.
+    Valid values are GET, POST, PUT, and DELETE
+
+.PARAMETER ScriptBlock
+    ScriptBlock that will be triggered when web route is called.
+
+.PARAMETER ScriptPath
+    Full path and name of script that will be triggered when web route is called.
+
+.PARAMETER Force
+    Use -Force to overwrite any existing web route for the same path and method.
+
+.EXAMPLE
+    New-WebRoute -Path "helloworld" -Method "GET" -ScriptBlock { $response.Send( 'Hello World' ) }
+
+    To view results:
+    Start-Polaris
+    Start-Process http://localhost:8080/helloworld
+
+.EXAMPLE
+    New-WebRoute -Path "helloworld" -Method "GET" -ScriptPath D:\Scripts\Example.ps1
+
+    To view results, assuming default port:
+    Start-Polaris
+    Start-Process http://localhost:8080/helloworld
+#>
+function New-WebRoute
+{
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$True, Position=0)]
+        [Parameter( Mandatory = $True, Position = 0 )]
         [string]
         $Path,
 
-        [Parameter(Mandatory=$True, Position=1)]
+        [Parameter( Mandatory = $True, Position = 1 )]
+        [ValidateSet( 'GET', 'POST', 'PUT', 'DELETE' )]
         [string]
         $Method,
 
-        [Parameter(Position=2)]
+        [Parameter( Mandatory = $True, Position = 2, ParameterSetName = 'ScriptBlock' )]
         [scriptblock]
         $ScriptBlock,
 
-        [Parameter()]
+        [Parameter( Mandatory = $True, ParameterSetName = 'ScriptPath' )]
         [string]
-        $ScriptPath)
-    CreateNewPolarisIfNeeded
-    if ($ScriptPath -ne $null -and $ScriptPath -ne "") {
-        if(-Not (Test-Path -Path $ScriptPath)) {
-            ThrowError -ExceptionName FileNotFoundException -ExceptionMessage "File does not exist at path $ScriptPath"
+        $ScriptPath,
+        
+        [switch]
+        $Force )
+
+    $ExistingWebRoute = Get-WebRoute -Path $Path -Method $Method
+
+    if ( $ExistingWebRoute -and $Force )
+    {
+        Remove-WebRoute -Path $Path -Method $Method
+        $ExistingWebRoute = Get-WebRoute -Path $Path -Method $Method
+    }
+
+    if ( $ExistingWebRoute )
+    {
+        $PSCmdlet.WriteError( (
+            New-Object -TypeName System.Management.Automation.ErrorRecord -ArgumentList @(
+                [System.Exception]'WebRoute already exists.'
+                $Null
+                [System.Management.Automation.ErrorCategory]::ResourceExists
+                "$Path,$Method" ) ) )
+    }
+    else
+    {
+        CreateNewPolarisIfNeeded
+
+        if ( -not $Path.StartsWith( '/' ) )
+        {
+            $Path = '/' + $Path
         }
 
-        $ScriptBlock = [ScriptBlock]::Create((Get-Content -Path $ScriptPath -Raw))
+        switch ( $PSCmdlet.ParameterSetName )
+        {
+            'ScriptBlock'
+            {
+                $global:Polaris.AddRoute( $Path, $Method, [string]$ScriptBlock )
+            }
+            'ScriptPath'
+            {
+                if ( Test-Path -Path $ScriptPath )
+                {
+                    $Script = Get-Content -Path $ScriptPath -Raw
+                    $global:Polaris.AddRoute( $Path, $Method, $Script )
+                }
+                else
+                {
+                    $PSCmdlet.WriteError( (
+                        New-Object -TypeName System.Management.Automation.ErrorRecord -ArgumentList @(
+                            [System.Exception]'ScriptPath not found.'
+                            $Null
+                            [System.Management.Automation.ErrorCategory]::ObjectNotFound
+                            $ScriptPath ) ) )
+                }
+            }
+        }
     }
-    $global:Polaris.AddRoute($Path, $Method, $ScriptBlock.ToString())
 }
 
 <#
 .SYNOPSIS
-Removes the web route.
+    Removes the web route.
 
 .DESCRIPTION
-Removes the web route with the specified path and method.
+    Removes the web route(s) matching the specified path(s) and method(s).
 
 .PARAMETER Path
-The path of the route you want to remove.
+    Path(s) of the route(s) to remove.
+    Accepts multiple values and wildcards.
+    Accepts pipeline input.
+    Accepts pipeline input by property name.
+    Defaults to all paths (*).
 
 .PARAMETER Method
-The method of the route you want to remove.
+    Method(s) of the route(s) to remove.
+    Accepts pipeline input by property name.
+    Accepts multiple values and wildcards.
+    Defaults to all methods (*).
 
 .EXAMPLE
-Remove-WebRoute -Path /out -Method PUT
+    Remove-WebRoute
 
+    Removes all existing web routes.
+
+.EXAMPLE
+    Remove-WebRoute -Path 'helloworld' -Method GET
+
+    Removes the web route for method GET for path helloworld.
+
+.EXAMPLE
+    Remove-WebRoute -Path 'sub1/sub2/*'
+
+    Removes all web routes for all methods for paths starting with sub1/sub2/.
+
+.EXAMPLE
+    Remove-WebRoute -Path 'sub1/sub2/*' -Method GET, POST
+
+    Removes all web routes for GET and POST methods for paths starting with sub1/sub2/.
+
+.EXAMPLE
+    Get-WebRoute -Method Delete | Remove-Method
+
+    Removes all web routes for DELETE methods for all paths.
 #>
-function Remove-WebRoute {
+function Remove-WebRoute
+{
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory=$True, Position=0)]
-        [string]
-        $Path,
+        [Parameter( ValueFromPipeline = $True,
+                    ValueFromPipelineByPropertyName = $True )]
+        [string[]]
+        $Path = '*',
 
-        [Parameter(Mandatory=$True, Position=1)]
-        [string]
-        $Method
-    )
-    if ($global:Polaris -ne $null) {
-        $global:Polaris.RemoveRoute($Path, $Method)
+        [Parameter( ValueFromPipelineByPropertyName = $True )]
+        [string[]]
+        $Method = '*' )
+
+    process
+    {
+        if ( $global:Polaris )
+        {
+            $WebRoutes = Get-WebRoute -Path $Path -Method $Method
+            
+            ForEach ( $Route in $WebRoutes )
+            {
+                $global:Polaris.RemoveRoute( $Route.Path, $Route.Method )
+            }
+        }
     }
 }
 
 <#
 .SYNOPSIS
-Get the object containing the routes.
+    Get web routes.
 
 .DESCRIPTION
-Get the object containing the routes. They are organized by Path -> Method -> Script block
+    Get web routes filtered by Path and Method, as specified.
+
+.PARAMETER Path
+    Path of the route(s) to get.
+    Accepts multiple values and wildcards.
+    Defaults to all paths (*).
+
+.PARAMETER Method
+    Method(s) of the route(s) to get.
+    Accepts multiple values and wildcards.
+    Defaults to all methods (*).
 
 .EXAMPLE
-Get-WebRoute
+    Get-WebRoute
 
+    Gets all web routes.
+
+.EXAMPLE
+    Get-WebRoute -Path 'helloworld' -Method 'GET'
+
+    Gets the web route for method GET for path helloworld.
+
+.EXAMPLE
+    Get-WebRoute -Path 'sub1/sub2/*'
+
+    Gets all web routes for all methods for paths starting with sub1/sub2/.
+
+.EXAMPLE
+    Get-WebRoute -Path 'sub1/sub2/*' -Method GET, POST
+
+    Gets all web routes for GET and POST methods for paths starting with sub1/sub2/.
+
+.EXAMPLE
+    Get-WebRoute -Method Delete
+
+    Gets all web routes for DELETE methods for all paths.
 #>
-function Get-WebRoute {
+function Get-WebRoute
+{
     [CmdletBinding()]
-    param()
+    param(
+        [string[]]
+        $Path = '*',
 
-    if ($global:Polaris -ne $null) {
-        return $global:Polaris.ScriptBlockRoutes
+        [string[]]
+        $Method = '*' )
+
+    if ( $global:Polaris )
+    {
+        $WebRoutes = [System.Collections.ArrayList]@()
+
+        ForEach ( $Route in $global:Polaris.ScriptBlockRoutes.GetEnumerator() )
+        {
+            ForEach ( $RouteMethod in $Route.Value.GetEnumerator() )
+            {
+                $Null = $WebRoutes.Add( [pscustomobject]@{ Path = $Route.Key; Method = $RouteMethod.Key; Scriptblock = $RouteMethod.Value } )
+            }
+        }
+
+        $Filter = [scriptblock]::Create( (
+            '( ' + 
+            ( $Path.ForEach({   "`$_.Path   -like `"$_`"" } ) -join ' -or ' ) + 
+            ' ) -and ( ' +
+            ( $Method.ForEach({ "`$_.Method -like `"$_`"" } ) -join ' -or ' ) +
+            ' )' ) )
+
+        $WebRoutes = $WebRoutes.Where( $Filter )
+
+        return $WebRoutes
     }
 }
 
-##############################
-#.SYNOPSIS
-# Defines routes to serve a folder at the "/" endpoint
-#
-#.DESCRIPTION
-# Defines routes to serve a folder at the "/" endpoint. Perfect for static websites.
-#
-#.PARAMETER RoutePath
-# (Optional) Root route that the folder path will be served to. Defaults to "/"
-#
-#.PARAMETER FolderPath
-# Path to the folder you want to serve.
-#
-#.EXAMPLE
-# New-StaticRoute -Path ./public
-#
-##############################
-function New-StaticRoute {
+<#
+.SYNOPSIS
+    Creates web routes to recursively serve folder contents
+
+.DESCRIPTION
+    Creates web routes to recursively serve folder contents. Perfect for static websites.
+
+.PARAMETER RoutePath
+    Root route that the folder path will be served to.
+    Defaults to "/".
+
+.PARAMETER FolderPath
+    Full path and name of the folder to serve.
+
+.PARAMETER Force
+    Use -Force to overwrite existing web route(s) for the same paths.
+
+.EXAMPLE
+    New-StaticRoute -RoutePath 'public' -Path D:\FolderShares\public
+
+    Creates web routes for GET method for each file recursively within D:\FolderShares\public
+    at relative path /public, for example, http://localhost:8080/public/File1.html
+
+.EXAMPLE
+    Get-WebRoute -Path 'public/*' -Method GET | Remove-WebRoute
+    New-StaticRoute -RoutePath 'public' -Path D:\FolderShares\public
+
+    Updates website web routes. (Deletes all existing web routes and creates new web routes
+    for all existing folder content.)
+
+.NOTES
+    Folders are not browsable. New files are not added dynamically.
+#>
+function New-StaticRoute
+{
     [CmdletBinding()]
     param(
-        [Parameter(Position=0)]
         [string]
         $RoutePath = "/",
 
-        [Parameter(Mandatory=$True, Position=1)]
+        [Parameter( Mandatory = $True )]
         [string]
-        $FolderPath)
+        $FolderPath,
+        
+        [switch]
+        $Force )
+    
     CreateNewPolarisIfNeeded
-    if(-Not (Test-Path -Path $FolderPath)) {
+    
+    if ( -not ( Test-Path -Path $FolderPath ) )
+    {
         ThrowError -ExceptionName FileNotFoundException -ExceptionMessage "Folder does not exist at path $FolderPath"
     }
 
     $allPaths = Get-ChildItem -Path $FolderPath -Recurse | ForEach-Object { $_.FullName }
-    $resolvedPath = (Resolve-Path -Path $FolderPath).Path
+    $resolvedPath = ( Resolve-Path -Path $FolderPath ).Path
 
+    $RoutePath = $RoutePath.TrimEnd( '/' )
 
-    $allPaths | ForEach-Object {
-    $scriptTemplate = @"
-if(`$PSVersionTable.PSEdition -eq "Core") {
-    `$bytes = Get-Content "$_" -AsByteStream -ReadCount 0
-} else {
-    `$bytes = Get-Content "$_" -Encoding Byte -ReadCount 0
-}
-`$response.SetContentType(([PolarisCore.PolarisResponse]::GetContentType("$_")))
-`$response.ByteResponse = `$bytes
-"@
+    ForEach ( $Path in $AllPaths )
+    {
+        $StaticPath = "$RoutePath$( $Path.Substring( $ResolvedPath.Length ).Replace( '\' , '/' ) )"
+        
+        If ( $PSVersionTable.PSEdition -eq "Core" )
+        {
+            $ByteParam = '-AsByteStream'
+        }
+        Else
+        {
+            $ByteParam = '-Encoding Byte'
+        }
 
-        New-GetRoute -Path "$($RoutePath.TrimEnd("/"))$($_.Substring($resolvedPath.Length).Replace('\','/'))" `
-            -ScriptBlock ([ScriptBlock]::Create($scriptTemplate))
+        $ScriptBlock = [ScriptBlock]::Create( @"
+            `$bytes = Get-Content -LiteralPath "$Path" $ByteParam -ReadCount 0
+            `$response.SetContentType( ( [PolarisCore.PolarisResponse]::GetContentType( "$Path" ) ) )
+            `$response.ByteResponse = `$bytes
+"@ )
+
+        New-WebRoute -Path $StaticPath -Method GET -ScriptBlock $ScriptBlock -Force:$Force
     }
 }
 
 <#
 .SYNOPSIS
-Add a new route middleware.
+    Add new route middleware.
 
 .DESCRIPTION
-Route middleware is used to manipulate request and response objects before it makes it to your route logic.
+    Creates new route middleware. Route middleware scripts are used to
+    manipulate request and response objects and run before web route scripts.
 
 .PARAMETER Name
-The name of the middleware.
+    Name of the middleware.
 
 .PARAMETER ScriptBlock
-The middleware script block that will be executed
+    ScriptBlock to run when middleware is triggered.
 
 .PARAMETER ScriptPath
-A path to the middleware script that will be executed
+    Full path and name to script to run when middleware is triggered.
+
+.PARAMETER Force
+    Use -Force to overwrite any existing middleware with the same name.
 
 .EXAMPLE
-$JsonBodyParserMiddlerware = {
+$JsonBodyParserMiddlerware =
+{
     if ($Request.BodyString -ne $null) {
         $Request.Body = $Request.BodyString | ConvertFrom-Json
     }
 }
 New-RouteMiddleware -Name JsonBodyParser -ScriptBlock $JsonBodyParserMiddleware
-
 #>
-function New-RouteMiddleware {
+function New-RouteMiddleware
+{
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$True, Position=0)]
+        [Parameter( Mandatory = $True, Position = 0 )]
         [string]
         $Name,
 
-        [Parameter(Position=1)]
+        [Parameter( Mandatory = $True, Position = 1, ParameterSetName = 'ScriptBlock' )]
         [scriptblock]
         $ScriptBlock,
 
-        [Parameter()]
+        [Parameter( Mandatory = $True, ParameterSetName = 'ScriptPath' )]
         [string]
-        $ScriptPath
-    )
-    CreateNewPolarisIfNeeded
-    if ($ScriptPath -ne $null -and $ScriptPath -ne "") {
-        if(-Not (Test-Path -Path $ScriptPath)) {
-            ThrowError -ExceptionName FileNotFoundException -ExceptionMessage "File does not exist at path $ScriptPath"
-        }
+        $ScriptPath,
+        
+        [switch]
+        $Force )
 
-        $ScriptBlock = [ScriptBlock]::Create((Get-Content -Path $ScriptPath -Raw))
+    $ExistingMiddleWare = Get-RouteMiddleware -Name $Name
+
+    if ( $ExistingMiddleWare -and $Force )
+    {
+        Remove-RouteMiddleware -Name $Name
+        $ExistingMiddleWare = Get-RouteMiddleware -Name $Name
     }
-    $global:Polaris.AddMiddleware($Name, $ScriptBlock.ToString())
+
+    if ( $ExistingMiddleWare )
+    {
+        $PSCmdlet.WriteError( (
+            New-Object -TypeName System.Management.Automation.ErrorRecord -ArgumentList @(
+                [System.Exception]'RouteMiddleware already exists.'
+                $Null
+                [System.Management.Automation.ErrorCategory]::ResourceExists
+                "$Name" ) ) )
+    }
+    else
+    {
+        CreateNewPolarisIfNeeded
+
+        switch ( $PSCmdlet.ParameterSetName )
+        {
+            'ScriptBlock'
+            {
+                $global:Polaris.AddMiddleware( $Name, [string]$ScriptBlock )
+            }
+            'ScriptPath'
+            {
+                if ( Test-Path -Path $ScriptPath )
+                {
+                    $Script = Get-Content -Path $ScriptPath -Raw
+                    $global:Polaris.AddMiddleware( $Name, $Script )
+                }
+                else
+                {
+                    $PSCmdlet.WriteError( (
+                        New-Object -TypeName System.Management.Automation.ErrorRecord -ArgumentList @(
+                            [System.Exception]'ScriptPath not found.'
+                            $Null
+                            [System.Management.Automation.ErrorCategory]::ObjectNotFound
+                            $ScriptPath ) ) )
+                }
+            }
+        }
+    }
 }
 
 <#
 .SYNOPSIS
-Removes the middleware.
+    Remove route middleware.
 
 .DESCRIPTION
-Removes the middleware from the list of middleware.
+    Remove route middleware matching the specified name(s).
 
 .PARAMETER Name
-The name of the middleware you want to remove.
+    Name of the middleware to remove.
+    Accepts multiple values and wildcards.
+    Accepts pipeline input.
+    Accepts pipeline input by property name.
+    Defaults to all names (*).
 
 .EXAMPLE
-Remove-RouteMiddleware -Name JsonBodyParser
+    Remove-RouteMiddleware -Name JsonBodyParser
 
+.EXAMPLE
+    Remove-RouteMiddleware
+
+    Removes all route middleware.
+
+.EXAMPLE
+    Remove-RouteMiddleware -Name ParamCheck*, ParamVerify*
+
+    Removes any route middleware with names starting with ParamCheck or ParamVerify.
+
+.EXAMPLE
+    Get-RouteMiddelware | Remove-RouteMiddleware
+
+    Removes all reoute middleware.
 #>
-function Remove-RouteMiddleware {
+function Remove-RouteMiddleware
+{
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$True, Position=0)]
-        [string]
-        $Name
-    )
-    if ($global:Polaris -ne $null) {
-        $global:Polaris.RemoveMiddleware($Name)
+        [Parameter( ValueFromPipeline = $True,
+                    ValueFromPipelineByPropertyName = $True )]
+        [string[]]
+        $Name = '*' )
+    
+    process
+    {
+        if ( $global:Polaris  )
+        {
+            $Middleware = Get-RouteMiddleware -Name $Name
+
+            ForEach ( $Ware in $MiddleWare )
+            {
+                $global:Polaris.RemoveMiddleware( $Ware.Name )
+            }
+        }
     }
 }
 
 <#
 .SYNOPSIS
-Get the route middlewares.
+    Get route middleware.
 
 .DESCRIPTION
-Get the route middlewares. You can optionally specify a name for a filter.
+    Get route middleware matching the specified name(s).
 
 .PARAMETER Name
-(Optional) The specific middleware you're looking for.
+    Name of the middleware to get.
+    Accepts multiple values and wildcards.
+    Defaults to all names (*).
 
 .EXAMPLE
-Get-RouteMiddleware
+    Get-RouteMiddleware
 
-Get-RouteMiddleware -Name JsonBodyParser
+.EXAMPLE
+    Get-RouteMiddleware -Name JsonBodyParser
 
+.EXAMPLE
+    Get-RouteMiddleware -Name ParamCheck*, ParamVerify*
 #>
-
-function Get-RouteMiddleware {
+function Get-RouteMiddleware
+{
     [CmdletBinding()]
     param(
-        [Parameter(Position=0)]
-        [string]
-        $Name
-    )
+        [string[]]
+        $Name = '*' )
 
-    if ($global:Polaris -ne $null) {
-        if ($Name -ne $null -and $Name -ne "") {
-            return $global:Polaris.RouteMiddleware.Where({ $_.Name -eq $Name })
-        }
-        return $global:Polaris.RouteMiddleware
+    if ( $global:Polaris )
+    {
+        $Filter = [scriptblock]::Create( ( $Name.ForEach({ "`$_.Name   -like `"$_`"" }) -join ' -or ' ) )
+
+        return $global:Polaris.RouteMiddleware.Where( $Filter )
     }
 }
 
-##############################
-#.SYNOPSIS
-# Starts the web server.
-#
-#.DESCRIPTION
-# Starts the web server.
-#
-#.PARAMETER Port
-# (Optional) The port you want the web server to run on. Defaults to 8080.
-#
-#.PARAMETER MinRunspaces
-# (Optional) The minimum ammount of PowerShell runspaces you'd like to use. Defaults to 1.
-#
-#.PARAMETER MaxRunspaces
-# (Optional) The maximum ammount of PowerShell runspaces you'd like to use. Defaults to 1.
-#
-#.PARAMETER UseJsonBodyParserMiddleware
-# (Optional) Will enable the Json body parser middleware.
-#
-#.EXAMPLE
-# Start-Polaris
-#
-# Start-Polaris -Port 8081
-#
-##############################
+<#
+.SYNOPSIS
+    Start Polaris web server.
+
+.DESCRIPTION
+    Start Polaris web server.
+
+.PARAMETER Port
+    Port number to listen on.
+    Defaults to 8080.
+
+.PARAMETER MinRunspaces
+    Minimum number of PowerShell runspaces for web server to use.
+    Defaults to 1.
+
+.PARAMETER MaxRunspaces
+    Maximum number of PowerShell runspaces for web server to use.
+    Defaults to 1.
+
+.PARAMETER UseJsonBodyParserMiddleware
+    When present, JSONBodyParser middleware will be created, if needed.
+
+.EXAMPLE
+    Start-Polaris
+
+.EXAMPLE
+    Start-Polaris -Port 8081 -MinRunspaces 2 -MaxRunspaces 10 -UseJsonBodyParserMiddleware
+#>
 function Start-Polaris {
     [CmdletBinding()]
     param(
-        [Parameter(Position=0)]
         [Int32]
         $Port = 8080,
 
-        [Parameter(Position=1)]
         [Int32]
         $MinRunspaces = 1,
 
-        [Parameter(Position=2)]
         [Int32]
         $MaxRunspaces = 1,
 
-        [Parameter()]
         [switch]
-        $UseJsonBodyParserMiddleware = $false
-        )
+        $UseJsonBodyParserMiddleware = $False )
+
     CreateNewPolarisIfNeeded
 
-    if ($UseJsonBodyParserMiddleware) {
+    if ( $UseJsonBodyParserMiddleware )
+    {
         New-RouteMiddleware -Name JsonBodyParser -ScriptBlock $JsonBodyParserMiddlerware
     }
 
-    $global:Polaris.Start($Port, $MinRunspaces, $MaxRunspaces)
+    $global:Polaris.Start( $Port, $MinRunspaces, $MaxRunspaces )
+    
     return $global:Polaris
 }
 
-##############################
-#.SYNOPSIS
-# Stops the web server.
-#
-#.DESCRIPTION
-# Stops the web server.
-#
-#.PARAMETER ServerContext
-# (Optional) The server that you wish to stop. Defaults to the global instance.
-#
-#.EXAMPLE
-# Stop-Polaris
-#
-# Stop-Polaris -ServerContext $app
-#
-##############################
-function Stop-Polaris {
+<#
+.SYNOPSIS
+    Stop Polaris web server.
+
+.DESCRIPTION
+    Stop Polaris web server.
+
+.PARAMETER ServerContext
+    Polaris instance to stop.
+    Defaults to the global instance.
+
+.EXAMPLE
+    Stop-Polaris
+
+.EXAMPLE
+    Stop-Polaris -ServerContext $app
+#>
+function Stop-Polaris
+{
     [CmdletBinding()]
     param(
-        [Parameter(Position=0)]
         [PolarisCore.Polaris]
-        $ServerContext = $global:Polaris)
-    if ($ServerContext -ne $null) {
+        $ServerContext = $global:Polaris )
+
+    if ( $ServerContext )
+    {
         $ServerContext.Stop()
-        try {
-            Invoke-RestMethod "http://localhost:$($global:Polaris.Port)/ping"
-        }
-        catch {
-            Write-Verbose "Server already stopped."
-        }
     }
 }
 
@@ -377,229 +636,290 @@ function Stop-Polaris {
 # HELPERS
 ##############################
 
-##############################
-#.SYNOPSIS
-# Adds a new Route with HTTP Method "GET"
-#
-#.DESCRIPTION
-# A shorthand version of doing New-WebRoute -Method "GET"
-#
-#.PARAMETER Path
-# The HTTP Route/Path/endpoint that you call to trigger this script
-#
-#.PARAMETER ScriptBlock
-# A script block that will be triggered when this HTTP Route/Path/endpoint has been called
-#
-#.PARAMETER ScriptPath
-# A path to a script that will be triggered when this HTTP Route/Path/endpoint has been called
-#
-#.EXAMPLE
-# New-GetRoute -Path "/helloworld" -ScriptBlock {
-#    $response.Send('Hello World')
-# }
-#
-# New-GetRoute -Path "/helloworld" -ScriptPath ./example.ps1
-#
-#.NOTES
-# Navigating to localhost:8080/helloworld would display the example.
-#
-##############################
-function New-GetRoute {
+<#
+.SYNOPSIS
+    Add web route with method GET
+
+.DESCRIPTION
+    Wrapper for New-WebRoute -Method GET
+
+.PARAMETER Path
+    Path (path/route/endpoint) of the web route to to be serviced.
+
+.PARAMETER ScriptBlock
+    ScriptBlock that will be triggered when web route is called.
+
+.PARAMETER ScriptPath
+    Full path and name of script that will be triggered when web route is called.
+
+.PARAMETER Force
+    Use -Force to overwrite any existing web route for the same path and method.
+
+.EXAMPLE
+    New-GetRoute -Path "helloworld" -ScriptBlock { $response.Send( 'Hello World' ) }
+
+    To view results:
+    Start-Polaris
+    Start-Process http://localhost:8080/helloworld
+
+.EXAMPLE
+    New-GetRoute -Path "helloworld" -ScriptPath D:\Scripts\Example.ps1
+
+    To view results, assuming default port:
+    Start-Polaris
+    Start-Process http://localhost:8080/helloworld
+#>
+function New-GetRoute
+{
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory=$True, Position=0)]
+        [Parameter( Mandatory = $True, Position = 0 )]
         [string]
         $Path,
 
-        [Parameter(Position=1, ParameterSetName = "ScriptBlock")]
+        [Parameter( Mandatory = $True, Position = 1, ParameterSetName = 'ScriptBlock' )]
         [scriptblock]
         $ScriptBlock,
 
-        [Parameter(ParameterSetName = "ScriptPath")]
+        [Parameter( Mandatory = $True, ParameterSetName = 'ScriptPath' )]
         [string]
-        $ScriptPath)
-    New-WebRoute -Path $Path -Method "GET" -ScriptBlock $ScriptBlock -ScriptPath $ScriptPath
-}
+        $ScriptPath,
+        
+        [switch]
+        $Force )
 
-##############################
-#.SYNOPSIS
-# Adds a new Route with HTTP Method "POST"
-#
-#.DESCRIPTION
-# A shorthand version of doing New-WebRoute -Method "POST"
-#
-#.PARAMETER Path
-# The HTTP Route/Path/endpoint that you call to trigger this script
-#
-#.PARAMETER ScriptBlock
-# A script block that will be triggered when this HTTP Route/Path/endpoint has been called
-#
-#.PARAMETER ScriptPath
-# A path to a script that will be triggered when this HTTP Route/Path/endpoint has been called
-#
-#.EXAMPLE
-# New-PostRoute -Path "/helloworld" -ScriptBlock {
-#    $response.Send('Hello World')
-# }
-#
-# New-PostRoute -Path "/helloworld" -ScriptPath ./example.ps1
-#
-#.NOTES
-# Calling to localhost:8080/helloworld with a POST request would display the example.
-#
-##############################
-function New-PostRoute {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory=$True, Position=0)]
-        [string]
-        $Path,
-
-        [Parameter(Position=1, ParameterSetName = "ScriptBlock")]
-        [scriptblock]
-        $ScriptBlock,
-
-        [Parameter(ParameterSetName = "ScriptPath")]
-        [string]
-        $ScriptPath)
-    New-WebRoute -Path $Path -Method "POST" -ScriptBlock $ScriptBlock -ScriptPath $ScriptPath
-}
-
-##############################
-#.SYNOPSIS
-# Adds a new Route with HTTP Method "PUT"
-#
-#.DESCRIPTION
-# A shorthand version of doing New-WebRoute -Method "PUT"
-#
-#.PARAMETER Path
-# The HTTP Route/Path/endpoint that you call to trigger this script
-#
-#.PARAMETER ScriptBlock
-# A script block that will be triggered when this HTTP Route/Path/endpoint has been called
-#
-#.PARAMETER ScriptPath
-# A path to a script that will be triggered when this HTTP Route/Path/endpoint has been called
-#
-#.EXAMPLE
-# New-PutRoute -Path "/helloworld" -ScriptBlock {
-#    $response.Send('Hello World')
-# }
-#
-# New-PutRoute -Path "/helloworld" -ScriptPath ./example.ps1
-#
-#.NOTES
-# Calling to localhost:8080/helloworld with a PUT request would display the example.
-#
-##############################
-function New-PutRoute {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory=$True, Position=0)]
-        [string]
-        $Path,
-
-        [Parameter(Position=1, ParameterSetName = "ScriptBlock")]
-        [scriptblock]
-        $ScriptBlock,
-
-        [Parameter(ParameterSetName = "ScriptPath")]
-        [string]
-        $ScriptPath)
-    New-WebRoute -Path $Path -Method "PUT" -ScriptBlock $ScriptBlock -ScriptPath $ScriptPath
-}
-
-##############################
-#.SYNOPSIS
-# Adds a new Route with HTTP Method "DELETE"
-#
-#.DESCRIPTION
-# A shorthand version of doing New-WebRoute -Method "DELETE"
-#
-#.PARAMETER Path
-# The HTTP Route/Path/endpoint that you call to trigger this script
-#
-#.PARAMETER ScriptBlock
-# A script block that will be triggered when this HTTP Route/Path/endpoint has been called
-#
-#.PARAMETER ScriptPath
-# A path to a script that will be triggered when this HTTP Route/Path/endpoint has been called
-#
-#.EXAMPLE
-# New-DeleteRoute -Path "/helloworld" -ScriptBlock {
-#    $response.Send('Hello World')
-# }
-#
-# New-DeleteRoute -Path "/helloworld" -ScriptPath ./example.ps1
-#
-#.NOTES
-# Calling to localhost:8080/helloworld with a DELETE request would display the example.
-#
-##############################
-function New-DeleteRoute {
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory=$True, Position=0)]
-        [string]
-        $Path,
-
-        [Parameter(Position=1, ParameterSetName = "ScriptBlock")]
-        [scriptblock]
-        $ScriptBlock,
-
-        [Parameter(ParameterSetName = "ScriptPath")]
-        [string]
-        $ScriptPath)
-    CreateNewPolarisIfNeeded
-    New-WebRoute -Path $Path -Method "DELETE" -ScriptBlock $ScriptBlock -ScriptPath $ScriptPath
+    switch ( $PSCmdlet.ParameterSetName )
+    {
+        'ScriptBlock' { New-WebRoute -Path $Path -Method "GET" -ScriptBlock $ScriptBlock -Force:$Force }
+        'ScriptPath'  { New-WebRoute -Path $Path -Method "GET" -ScriptPath  $ScriptPath  -Force:$Force }
+    }
 }
 
 <#
 .SYNOPSIS
-Helper function that turns on the Json Body parsing middleware.
+    Add web route with method POST
 
 .DESCRIPTION
-Helper function that turns on the Json Body parsing middleware.
+    Wrapper for New-WebRoute -Method POST
+
+.PARAMETER Path
+    Path (path/route/endpoint) of the web route to to be serviced.
+
+.PARAMETER ScriptBlock
+    ScriptBlock that will be triggered when web route is called.
+
+.PARAMETER ScriptPath
+    Full path and name of script that will be triggered when web route is called.
+
+.PARAMETER Force
+    Use -Force to overwrite any existing web route for the same path and method.
 
 .EXAMPLE
-Use-JsonBodyParserMiddleware
+    New-GetRoute -Path "helloworld" -ScriptBlock { $response.Send( 'Hello World' ) }
 
+    To view results, assuming default port:
+    Start-Polaris
+    Invoke-WebRequest -Uri http://localhost:8080/helloworld -Method POST
+
+.EXAMPLE
+    New-GetRoute -Path "helloworld" -ScriptPath D:\Scripts\Example.ps1
+
+    To view results, assuming default port:
+    Start-Polaris
+    Invoke-WebRequest -Uri http://localhost:8080/helloworld -Method POST
+#>
+function New-PostRoute
+{
+    [CmdletBinding()]
+    param(
+        [Parameter( Mandatory = $True, Position = 0 )]
+        [string]
+        $Path,
+
+        [Parameter( Mandatory = $True, Position = 1, ParameterSetName = 'ScriptBlock' )]
+        [scriptblock]
+        $ScriptBlock,
+
+        [Parameter( Mandatory = $True, ParameterSetName = 'ScriptPath' )]
+        [string]
+        $ScriptPath,
+        
+        [switch]
+        $Force )
+
+    switch ( $PSCmdlet.ParameterSetName )
+    {
+        'ScriptBlock' { New-WebRoute -Path $Path -Method "POST" -ScriptBlock $ScriptBlock -Force:$Force }
+        'ScriptPath'  { New-WebRoute -Path $Path -Method "PSOT" -ScriptPath  $ScriptPath  -Force:$Force }
+    }
+}
+
+<#
+.SYNOPSIS
+    Add web route with method PUT
+
+.DESCRIPTION
+    Wrapper for New-WebRoute -Method PUT
+
+.PARAMETER Path
+    Path (path/route/endpoint) of the web route to to be serviced.
+
+.PARAMETER ScriptBlock
+    ScriptBlock that will be triggered when web route is called.
+
+.PARAMETER ScriptPath
+    Full path and name of script that will be triggered when web route is called.
+
+.PARAMETER Force
+    Use -Force to overwrite any existing web route for the same path and method.
+
+.EXAMPLE
+    New-GetRoute -Path "helloworld" -ScriptBlock { $response.Send( 'Hello World' ) }
+
+    To view results, assuming default port:
+    Start-Polaris
+    Invoke-WebRequest -Uri http://localhost:8080/helloworld -Method PUT
+
+.EXAMPLE
+    New-GetRoute -Path "helloworld" -ScriptPath D:\Scripts\Example.ps1
+
+    To view results, assuming default port:
+    Start-Polaris
+    Invoke-WebRequest -Uri http://localhost:8080/helloworld -Method PUT
+#>
+function New-PutRoute {
+    [CmdletBinding()]
+    param(
+        [Parameter( Mandatory = $True, Position = 0 )]
+        [string]
+        $Path,
+
+        [Parameter( Mandatory = $True, Position = 1, ParameterSetName = 'ScriptBlock' )]
+        [scriptblock]
+        $ScriptBlock,
+
+        [Parameter( Mandatory = $True, ParameterSetName = 'ScriptPath' )]
+        [string]
+        $ScriptPath,
+        
+        [switch]
+        $Force )
+
+    switch ( $PSCmdlet.ParameterSetName )
+    {
+        'ScriptBlock' { New-WebRoute -Path $Path -Method "PUT" -ScriptBlock $ScriptBlock -Force:$Force }
+        'ScriptPath'  { New-WebRoute -Path $Path -Method "PUT" -ScriptPath  $ScriptPath  -Force:$Force }
+    }
+}
+
+<#
+.SYNOPSIS
+    Add web route with method DELETE
+
+.DESCRIPTION
+    Wrapper for New-WebRoute -Method DELETE
+
+.PARAMETER Path
+    Path (path/route/endpoint) of the web route to to be serviced.
+
+.PARAMETER ScriptBlock
+    ScriptBlock that will be triggered when web route is called.
+
+.PARAMETER ScriptPath
+    Full path and name of script that will be triggered when web route is called.
+
+.PARAMETER Force
+    Use -Force to overwrite any existing web route for the same path and method.
+
+.EXAMPLE
+    New-GetRoute -Path "helloworld" -ScriptBlock { $response.Send( 'Hello World' ) }
+
+    To view results, assuming default port:
+    Start-Polaris
+    Invoke-WebRequest -Uri http://localhost:8080/helloworld -Method DELETE
+
+.EXAMPLE
+    New-GetRoute -Path "helloworld" -ScriptPath D:\Scripts\Example.ps1
+
+    To view results, assuming default port:
+    Start-Polaris
+    Invoke-WebRequest -Uri http://localhost:8080/helloworld -Method DELETE
+#>
+function New-DeleteRoute {
+    [CmdletBinding()]
+    param(
+        [Parameter( Mandatory = $True, Position = 0 )]
+        [string]
+        $Path,
+
+        [Parameter( Mandatory = $True, Position = 1, ParameterSetName = 'ScriptBlock' )]
+        [scriptblock]
+        $ScriptBlock,
+
+        [Parameter( Mandatory = $True, ParameterSetName = 'ScriptPath' )]
+        [string]
+        $ScriptPath,
+        
+        [switch]
+        $Force )
+
+    switch ( $PSCmdlet.ParameterSetName )
+    {
+        'ScriptBlock' { New-WebRoute -Path $Path -Method "DELETE" -ScriptBlock $ScriptBlock -Force:$Force }
+        'ScriptPath'  { New-WebRoute -Path $Path -Method "DELETE" -ScriptPath  $ScriptPath  -Force:$Force }
+    }
+}
+
+<#
+.SYNOPSIS
+    Helper function that turns on the Json Body parsing middleware.
+
+.DESCRIPTION
+    Helper function that turns on the Json Body parsing middleware.
+
+.EXAMPLE
+    Use-JsonBodyParserMiddleware
 #>
 function Use-JsonBodyParserMiddleware {
     [CmdletBinding()]
     param()
 
-    New-RouteMiddleware -Name JsonBodyParser -ScriptBlock $JsonBodyParserMiddlerware
+    New-RouteMiddleware -Name JsonBodyParser -ScriptBlock $JsonBodyParserMiddlerware -Force
 }
 
 ##############################
 # INTERNAL
 ##############################
-function CreateNewPolarisIfNeeded () {
-    if ($global:Polaris -eq $null) {
-        [Action[string]]$logger = { param($str) Write-Verbose "$str" }
-        $global:Polaris = New-Object -TypeName PolarisCore.Polaris -ArgumentList $logger
+
+function CreateNewPolarisIfNeeded ()
+{
+    if ( -not $global:Polaris )
+    {
+        $global:Polaris = New-Object -TypeName PolarisCore.Polaris -ArgumentList @(
+            [Action[string]]{ param($str) Write-Verbose "$str" } )
     }
 }
 
-$JsonBodyParserMiddlerware = {
-    if ($Request.BodyString -ne $null) {
+$JsonBodyParserMiddlerware =
+{
+    if ( $Request.BodyString -ne $Null )
+    {
         $Request.Body = $Request.BodyString | ConvertFrom-Json
     }
 }
 
 Export-ModuleMember -Function `
-    New-WebRoute, `
-    Remove-WebRoute, `
-    Get-WebRoute, `
-    New-GetRoute, `
-    New-PostRoute, `
-    New-PutRoute, `
-    New-DeleteRoute, `
-    New-StaticRoute, `
-    New-RouteMiddleware, `
-    Remove-RouteMiddleware, `
-    Get-RouteMiddleware, `
-    Use-JsonBodyParserMiddleware, `
-    Start-Polaris, `
+    New-WebRoute,
+    Remove-WebRoute,
+    Get-WebRoute,
+    New-GetRoute,
+    New-PostRoute,
+    New-PutRoute,
+    New-DeleteRoute,
+    New-StaticRoute,
+    New-RouteMiddleware,
+    Remove-RouteMiddleware,
+    Get-RouteMiddleware,
+    Use-JsonBodyParserMiddleware,
+    Start-Polaris,
     Stop-Polaris

--- a/Polaris.psm1
+++ b/Polaris.psm1
@@ -242,9 +242,9 @@ function Get-WebRoute
 
             $Filter = [scriptblock]::Create( (
                 '( ' + 
-                ( $Path.ForEach({   "`$_.Path   -like `"$_`"" } ) -join ' -or ' ) + 
+                ( $Path.ForEach({   "`$_.Path   -like `"$($_.TrimStart('/'))`"" } ) -join ' -or ' ) + 
                 ' ) -and ( ' +
-                ( $Method.ForEach({ "`$_.Method -like `"$_`"" } ) -join ' -or ' ) +
+                ( $Method.ForEach({ "`$_.Method -like `"$($_.TrimStart('/'))`"" } ) -join ' -or ' ) +
                 ' )' ) )
 
             $WebRoutes = $WebRoutes.Where( $Filter )

--- a/test/Get-RouteMiddleware.Tests.ps1
+++ b/test/Get-RouteMiddleware.Tests.ps1
@@ -3,7 +3,7 @@
     BeforeAll {
         
         #  Import module
-        Import-Module -Name Polaris
+        Import-Module "$PSScriptRoot\..\Polaris.psd1"
 
         #  Start with a clean slate
         Remove-RouteMiddleware

--- a/test/Get-RouteMiddleware.Tests.ps1
+++ b/test/Get-RouteMiddleware.Tests.ps1
@@ -3,7 +3,7 @@
     BeforeAll {
         
         #  Import module
-        Import-Module "$PSScriptRoot\..\Polaris.psd1"
+        Import-Module ..\Polaris.psd1
 
         #  Start with a clean slate
         Remove-RouteMiddleware

--- a/test/Get-RouteMiddleware.Tests.ps1
+++ b/test/Get-RouteMiddleware.Tests.ps1
@@ -1,0 +1,68 @@
+﻿Describe "Get-RouteMiddleware" {
+
+    BeforeAll {
+        
+        #  Import module
+        Import-Module -Name Polaris
+
+        #  Start with a clean slate
+        Remove-RouteMiddleware
+
+        #  Create middleware to test against
+        New-RouteMiddleware -Name 'Test0'  -ScriptBlock {}
+        New-RouteMiddleware -Name 'Test1'  -ScriptBlock {}
+        New-RouteMiddleware -Name 'Test2A' -ScriptBlock {}
+        New-RouteMiddleware -Name 'Test2B' -ScriptBlock {}
+        New-RouteMiddleware -Name 'Test3A' -ScriptBlock {}
+        New-RouteMiddleware -Name 'Test3B' -ScriptBlock {}
+        New-RouteMiddleware -Name 'Test3C' -ScriptBlock {}
+        New-RouteMiddleware -Name 'Test4A' -ScriptBlock {}
+        New-RouteMiddleware -Name 'Test4B' -ScriptBlock {}
+        New-RouteMiddleware -Name 'Test5A' -ScriptBlock {}
+        New-RouteMiddleware -Name 'Test5B' -ScriptBlock {}
+        New-RouteMiddleware -Name 'Test6'  -ScriptBlock {}
+        }
+
+    It "Should default to get all middleware" {
+        $ExpectedCount = $Global:Polaris.RouteMiddleware.Count
+
+        $Middleware = Get-RouteMiddleware
+        @( $Middleware ).Count | Should Be $ExpectedCount
+        }
+
+    It "Should respect Name" {
+        $Middleware = Get-RouteMiddleware -Name 'Test1'
+        @( $Middleware ).Count | Should Be 1
+        }
+
+    It "Should do nothing when no middleware match" {
+        $Middleware = Get-RouteMiddleware -Name 'DoesNotExist'
+        @( $Middleware ).Count | Should Be 0
+        }
+
+    It "Should accept multiple values for Name" {
+        $Middleware = Get-RouteMiddleware -Name 'Test3A', 'Test3B'
+        @( $Middleware ).Count | Should Be 2
+        }
+
+    It "Should accept wildcard values for Name" {
+        $Middleware = Get-RouteMiddleware -Name 'Test4*'
+        @( $Middleware ).Count | Should Be 2
+        }
+
+    It "Should accept pipeline input for Name" {
+        $Middleware = 'Test5A', 'Test5B' | Get-RouteMiddleware
+        @( $Middleware ).Count | Should Be 2
+        }
+
+    It "Should accept pipeline property input for Name" {
+        $Middleware = Get-RouteMiddleware -Name 'Test4*' | Get-RouteMiddleware
+        @( $Middleware ).Count | Should Be 2
+        }
+
+    AfterAll {
+
+        #  Clean up test middleware
+        Remove-RouteMiddleware
+        }
+    }

--- a/test/Get-WebRoute.Tests.ps1
+++ b/test/Get-WebRoute.Tests.ps1
@@ -2,7 +2,7 @@
     BeforeAll {
 
         #  Import module
-        Import-Module "$PSScriptRoot\..\Polaris.psd1"
+        Import-Module ..\Polaris.psd1
 
         #  Start with a clean slate
         Remove-WebRoute

--- a/test/Get-WebRoute.Tests.ps1
+++ b/test/Get-WebRoute.Tests.ps1
@@ -1,0 +1,86 @@
+﻿Describe "Get-WebRoute" {
+    BeforeAll {
+
+        #  Import module
+        Import-Module -Name Polaris
+
+        #  Start with a clean slate
+        Remove-WebRoute
+
+        #  Create test route to test against
+        New-WebRoute -Path 'Test0'  -Method GET  -ScriptBlock {}
+        New-WebRoute -Path 'Test0'  -Method POST -ScriptBlock {}
+        New-WebRoute -Path 'Test1'  -Method GET  -ScriptBlock {}
+        New-WebRoute -Path 'Test2'  -Method GET  -ScriptBlock {}
+        New-WebRoute -Path 'Test2'  -Method POST -ScriptBlock {}
+        New-WebRoute -Path 'Test3A' -Method PUT  -ScriptBlock {}
+        New-WebRoute -Path 'Test3B' -Method PUT  -ScriptBlock {}
+        New-WebRoute -Path 'Test3C' -Method GET  -ScriptBlock {}
+        New-WebRoute -Path 'Test4A' -Method PUT  -ScriptBlock {}
+        New-WebRoute -Path 'Test4B' -Method PUT  -ScriptBlock {}
+        New-WebRoute -Path 'Test5'  -Method GET  -ScriptBlock {}
+        New-WebRoute -Path 'Test5'  -Method POST -ScriptBlock {}
+        New-WebRoute -Path 'Test5'  -Method PUT  -ScriptBlock {}
+        New-WebRoute -Path 'Test6A' -Method GET  -ScriptBlock {}
+        New-WebRoute -Path 'Test6B' -Method GET  -ScriptBlock {}
+        New-WebRoute -Path 'Test7'  -Method POST -ScriptBlock {}
+        New-WebRoute -Path 'Test7'  -Method PUT  -ScriptBlock {}
+        }
+
+    It "Should default to get all routes" {
+        $ExpectedCount = $Global:Polaris.ScriptBlockRoutes.Values.Values.Count
+        $Routes = Get-WebRoute
+        @( $Routes ).Count | Should Be $ExpectedCount
+        }
+
+    It "Should respect Path" {
+        $Routes = Get-WebRoute -Path 'Test2'
+        @( $Routes ).Count | Should Be 2
+        }
+
+    It "Should respect Method" {
+        $Routes = Get-WebRoute -Path 'Test3*' -Method PUT
+        @( $Routes ).Count | Should Be 2
+        }
+
+    It "Should do nothing when no routes match" {
+        $Routes = Get-WebRoute -Path 'DOESNOTEXIST'
+        @( $Routes ).Count | Should Be 0
+        }
+
+    It "Should accept multiple values for Path" {
+        $Routes = Get-WebRoute -Path 'Test4A', 'Test4B'
+        @( $Routes ).Count | Should Be 2
+        }
+
+    It "Should accept multiple values for Method" {
+        $Routes = Get-WebRoute -Path 'Test5' -Method GET, POST
+        @( $Routes ).Count | Should Be 2
+        }
+
+    It "Should accept wildcard values for Path" {
+        $Routes = Get-WebRoute -Path 'Test6*'
+        @( $Routes ).Count | Should Be 2
+        }
+
+    It "Should accept wildcard values for Method" {
+        $Routes = Get-WebRoute -Path 'Test7' -Method 'P*'
+        @( $Routes ).Count | Should Be 2
+        }
+
+    It "Should accept pipeline input for Path" {
+        $Routes = 'Test6A', 'Test6B' | Get-WebRoute
+        @( $Routes ).Count | Should Be 2
+        }
+
+    It "Should accept pipeline property input for Path and Method" {
+        $Routes = Get-WebRoute -Path 'Test7' | Get-WebRoute
+        @( $Routes ).Count | Should Be 2
+        }
+
+    AfterAll {
+
+        #  Clean up test routes
+        Remove-WebRoute
+        }
+    }

--- a/test/Get-WebRoute.Tests.ps1
+++ b/test/Get-WebRoute.Tests.ps1
@@ -2,7 +2,7 @@
     BeforeAll {
 
         #  Import module
-        Import-Module -Name Polaris
+        Import-Module "$PSScriptRoot\..\Polaris.psd1"
 
         #  Start with a clean slate
         Remove-WebRoute

--- a/test/Helpers.Tests.ps1
+++ b/test/Helpers.Tests.ps1
@@ -1,0 +1,150 @@
+﻿Describe "Helper functions" {
+
+    BeforeAll {
+        
+        #  Import module
+        Import-Module -Name Polaris
+
+        #  Create test folder
+        $GUID = [string][guid]::NewGuid()
+        $TestPath = ( New-Item -Path $Env:Temp -Name $GUID -ItemType Directory ).FullName
+        
+        #  Create test script
+        $ScriptPath = "$TestPath\TestScript.ps1"
+        $Script = 'Script'
+        $Script | Out-File -FilePath $ScriptPath -NoNewline
+
+        #  Start with a clean slate
+        Remove-WebRoute
+        }
+
+    Context "New-GetRoute" {
+
+        It "Should create GET route" {
+
+            #  Define route
+            $Method = "GET"
+            $Path   = "TestRoute$Method"
+            $Scriptblock = [scriptblock]::Create( $Path )
+
+            #  Create route
+            New-GetRoute -Path $Path -ScriptBlock $Scriptblock
+
+            #  Test route
+            ( Get-WebRoute -Path $Path -Method $Method ).Scriptblock | Should Be $Path
+            }
+
+        It "Should create GET route with Scriptpath" {
+
+            #  Define route
+            $Method = 'GET'
+            $Path   = "TestScriptBlockRoute$Method"
+
+            #  Create route
+            New-GetRoute -Path $Path -ScriptPath $ScriptPath
+
+            #  Test route
+            ( Get-WebRoute -Path $Path -Method $Method ).Scriptblock | Should Be $Script
+            }
+        }
+
+    Context "New-PostRoute" {
+
+        It "Should create POST route" {
+
+            #  Define route
+            $Method = "POST"
+            $Path   = "TestRoute$Method"
+            $Scriptblock = [scriptblock]::Create( $Path )
+
+            #  Create route
+            New-PostRoute -Path $Path -ScriptBlock $Scriptblock
+
+            #  Test route
+            ( Get-WebRoute -Path $Path -Method $Method ).Scriptblock | Should Be $Path
+            }
+
+        It "Should create POST route with Scriptpath" {
+
+            #  Define route
+            $Method = 'POST'
+            $Path   = "TestScriptBlockRoute$Method"
+
+            #  Create route
+            New-PostRoute -Path $Path -ScriptPath $ScriptPath
+
+            #  Test route
+            ( Get-WebRoute -Path $Path -Method $Method ).Scriptblock | Should Be $Script
+            }
+        }
+
+    Context "New-PutRoute" {
+
+        It "Should create PUT route" {
+
+            #  Define route
+            $Method = "PUT"
+            $Path   = "TestRoute$Method"
+            $Scriptblock = [scriptblock]::Create( $Path )
+
+            #  Create route
+            New-PutRoute -Path $Path -ScriptBlock $Scriptblock
+
+            #  Test route
+            ( Get-WebRoute -Path $Path -Method $Method ).Scriptblock | Should Be $Path
+            }
+
+        It "Should create PUT route with Scriptpath" {
+
+            #  Define route
+            $Method = 'PUT'
+            $Path   = "TestScriptBlockRoute$Method"
+
+            #  Create route
+            New-PutRoute -Path $Path -ScriptPath $ScriptPath
+
+            #  Test route
+            ( Get-WebRoute -Path $Path -Method $Method ).Scriptblock | Should Be $Script
+            }
+        }
+
+    Context "New-DeleteRoute" {
+
+        It "Should create DELETE route" {
+
+            #  Define route
+            $Method = "DELETE"
+            $Path   = "TestRoute$Method"
+            $Scriptblock = [scriptblock]::Create( $Path )
+
+            #  Create route
+            New-DeleteRoute -Path $Path -ScriptBlock $Scriptblock
+ 
+            #  Test route
+           ( Get-WebRoute -Path $Path -Method $Method ).Scriptblock | Should Be $Path
+            }
+
+        It "Should create DELETE route with Scriptpath" {
+
+            #  Define route
+            $Method = 'DELETE'
+            $Path   = "TestScriptBlockRoute$Method"
+
+            #  Create route
+            New-DeleteRoute -Path $Path -ScriptPath $ScriptPath
+
+            #  Test route
+            ( Get-WebRoute -Path $Path -Method $Method ).Scriptblock | Should Be $Script
+            }
+        }
+
+    AfterAll {
+
+        #  Clean up test routes
+        Remove-WebRoute
+
+        #  Clean up test folder
+        Get-ChildItem -Path $TestPath -Recurse | Remove-Item -Recurse -Force
+        Remove-Item -Path $TestPath
+        }
+    }

--- a/test/Helpers.Tests.ps1
+++ b/test/Helpers.Tests.ps1
@@ -3,14 +3,10 @@
     BeforeAll {
         
         #  Import module
-        Import-Module -Name Polaris
+        Import-Module "$PSScriptRoot\..\Polaris.psd1"
 
-        #  Create test folder
-        $GUID = [string][guid]::NewGuid()
-        $TestPath = ( New-Item -Path $Env:Temp -Name $GUID -ItemType Directory ).FullName
-        
         #  Create test script
-        $ScriptPath = "$TestPath\TestScript.ps1"
+        $ScriptPath = 'TestDrive:\TestScript.ps1'
         $Script = 'Script'
         $Script | Out-File -FilePath $ScriptPath -NoNewline
 
@@ -142,9 +138,5 @@
 
         #  Clean up test routes
         Remove-WebRoute
-
-        #  Clean up test folder
-        Get-ChildItem -Path $TestPath -Recurse | Remove-Item -Recurse -Force
-        Remove-Item -Path $TestPath
         }
     }

--- a/test/Helpers.Tests.ps1
+++ b/test/Helpers.Tests.ps1
@@ -3,7 +3,7 @@
     BeforeAll {
         
         #  Import module
-        Import-Module "$PSScriptRoot\..\Polaris.psd1"
+        Import-Module ..\Polaris.psd1
 
         #  Create test script
         $ScriptPath = 'TestDrive:\TestScript.ps1'

--- a/test/New-RouteMiddleware.Tests.ps1
+++ b/test/New-RouteMiddleware.Tests.ps1
@@ -5,10 +5,6 @@
         #  Import module
         Import-Module ..\Polaris.psd1
 
-        #  Create test folder
-        $GUID = [string][guid]::NewGuid()
-        $TestPath = ( New-Item -Path $Env:Temp -Name $GUID -ItemType Directory ).FullName
-        
         #  Start with a clean slate
         Remove-RouteMiddleware
         }
@@ -30,7 +26,7 @@
 
         #  Define middleware
         $Name   = "TestMiddlewareScriptPath"
-        $ScriptPath = "$TestPath\$Name.ps1"
+        $ScriptPath = "TestDrive:\$Name.ps1"
 
         #  Create script file
         $Name | Out-File -FilePath $ScriptPath -NoNewline
@@ -46,7 +42,7 @@
 
         #  Define middleware
         $Name   = "TestScriptPathNotFound"
-        $ScriptPath = "$TestPath\DOESNOTEXIST.ps1"
+        $ScriptPath = "TestDrive:\DOESNOTEXIST.ps1"
 
         #  Create middleware
         { New-RouteMiddleware -Name $Name -ScriptPath $ScriptPath -ErrorAction Stop } |
@@ -85,9 +81,5 @@
 
         #  Clean up test middleware
         Remove-RouteMiddleware
-
-        #  Clean up test folder
-        Get-ChildItem -Path $TestPath -Recurse | Remove-Item -Recurse -Force
-        Remove-Item -Path $TestPath
         }
     }

--- a/test/New-RouteMiddleware.Tests.ps1
+++ b/test/New-RouteMiddleware.Tests.ps1
@@ -49,7 +49,8 @@
         $ScriptPath = "$TestPath\DOESNOTEXIST.ps1"
 
         #  Create middleware
-        New-RouteMiddleware -Name $Name -ScriptPath $ScriptPath
+        { New-RouteMiddleware -Name $Name -ScriptPath $ScriptPath -ErrorAction Stop } |
+            Should Throw
         }
 
     It "Should throw error if middleware exists" {
@@ -62,7 +63,8 @@
         New-RouteMiddleware -Name $Name -ScriptBlock $Scriptblock
 
         #  Create middleware
-        New-RouteMiddleware -Name $Name -ScriptBlock $Scriptblock | Should Throw
+        { New-RouteMiddleware -Name $Name -ScriptBlock $Scriptblock -ErrorAction Stop } |
+            Should Throw
         }
 
     It "Should overwrite middleware with Force switch" {

--- a/test/New-RouteMiddleware.Tests.ps1
+++ b/test/New-RouteMiddleware.Tests.ps1
@@ -1,0 +1,91 @@
+﻿Describe "New-RouteMiddleware" {
+
+    BeforeAll {
+
+        #  Import module
+        Import-Module -Name Polaris
+
+        #  Create test folder
+        $GUID = [string][guid]::NewGuid()
+        $TestPath = ( New-Item -Path $Env:Temp -Name $GUID -ItemType Directory ).FullName
+        
+        #  Start with a clean slate
+        Remove-RouteMiddleware
+        }
+
+    It "Should create middleware" {
+
+        #  Define middleware
+        $Name   = "TestMiddleware"
+        $Scriptblock = [scriptblock]::Create( $Name )
+
+        #  Create middleware
+        New-RouteMiddleware -Name $Name -ScriptBlock $Scriptblock
+
+        #  Test middleware
+        ( Get-RouteMiddleware -Name $Name ).Scriptblock | Should Be $Name
+        }
+
+    It "Should create middleware with Scriptpath" {
+
+        #  Define middleware
+        $Name   = "TestMiddlewareScriptPath"
+        $ScriptPath = "$TestPath\$Name.ps1"
+
+        #  Create script file
+        $Name | Out-File -FilePath $ScriptPath -NoNewline
+
+        #  Create middleware
+        New-RouteMiddleware -Name $Name -ScriptPath $ScriptPath
+
+        #  Test middleware
+        ( Get-RouteMiddleware -Name $Name ).Scriptblock | Should Be $Name
+        }
+
+    It "Should throw error if Scriptpath not found" {
+
+        #  Define middleware
+        $Name   = "TestScriptPathNotFound"
+        $ScriptPath = "$TestPath\DOESNOTEXIST.ps1"
+
+        #  Create middleware
+        New-RouteMiddleware -Name $Name -ScriptPath $ScriptPath
+        }
+
+    It "Should throw error if middleware exists" {
+
+        #  Define middleware
+        $Name   = "TestExisting"
+        $Scriptblock = [scriptblock]::Create( $Name )
+
+        #  Create middleware
+        New-RouteMiddleware -Name $Name -ScriptBlock $Scriptblock
+
+        #  Create middleware
+        New-RouteMiddleware -Name $Name -ScriptBlock $Scriptblock | Should Throw
+        }
+
+    It "Should overwrite middleware with Force switch" {
+
+        #  Define middleware
+        $Name   = "TestExistingWithForce"
+        $NewContent = "NewContent"
+        $Scriptblock = [scriptblock]::Create( $NewContent )
+
+        #  Create middleware
+        New-RouteMiddleware -Name $Name -ScriptBlock $Scriptblock
+
+        #  Test middleware
+        ( Get-RouteMiddleware -Name $Name ).Scriptblock | Should Be $NewContent
+        }
+
+    AfterAll {
+
+        #  Clean up test middleware
+        Remove-RouteMiddleware
+
+        #  Clean up test folder
+        Get-ChildItem -Path $TestPath -Recurse | Remove-Item -Recurse -Force
+        Remove-Item -Path $TestPath
+        }
+    }

--- a/test/New-RouteMiddleware.Tests.ps1
+++ b/test/New-RouteMiddleware.Tests.ps1
@@ -3,7 +3,7 @@
     BeforeAll {
 
         #  Import module
-        Import-Module -Name Polaris
+        Import-Module "$PSScriptRoot\..\Polaris.psd1"
 
         #  Create test folder
         $GUID = [string][guid]::NewGuid()

--- a/test/New-RouteMiddleware.Tests.ps1
+++ b/test/New-RouteMiddleware.Tests.ps1
@@ -3,7 +3,7 @@
     BeforeAll {
 
         #  Import module
-        Import-Module "$PSScriptRoot\..\Polaris.psd1"
+        Import-Module ..\Polaris.psd1
 
         #  Create test folder
         $GUID = [string][guid]::NewGuid()

--- a/test/New-StaticRoute.Tests.ps1
+++ b/test/New-StaticRoute.Tests.ps1
@@ -1,0 +1,110 @@
+﻿Describe "New-StaticRoute" {
+
+    BeforeAll {
+
+        #  Import module
+        Import-Module -Name Polaris
+
+        #  Start with a clean slate
+        Remove-WebRoute
+
+        #  Create test folders
+        $GUID = [string][guid]::NewGuid()
+        $TestPath   = ( New-Item -Path $Env:Temp -Name $GUID  -ItemType Directory ).FullName
+        $TestFolder = ( New-Item -Path $TestPath -Name 'Sub1' -ItemType Directory ).FullName
+        
+        #  Create test files
+        $File1 =  ( New-Item -Path $TestPath   -Name 'File1.txt' -ItemType File ).FullName
+        $Null  =    New-Item -Path $TestPath   -Name 'File2.txt' -ItemType File
+        $Null  =    New-Item -Path $TestFolder -Name 'File3.txt' -ItemType File
+        $Null  =    New-Item -Path $TestFolder -Name 'File4.txt' -ItemType File
+
+        #  Define expected routes
+        $Paths = @(
+            'BaseRoot/File1.txt'
+            'BaseRoot/File2.txt'
+            'BaseRoot/Sub1/File3.txt'
+            'BaseRoot/Sub1/File4.txt' )
+
+        #  Add content to a file
+        $File1Uri = 'http://localhost:8080/BaseRoot/File1.txt'
+        $File1Content = 'File1Content'
+        $File1Content | Out-File -FilePath $File1 -Encoding ascii -NoNewline
+
+        ####  Create static routes
+        New-StaticRoute -RoutePath 'BaseRoot' -FolderPath $TestPath
+
+        #  Start Polaris server
+        #  Wrapped due to ignore bugs in current version
+        try
+            {
+            $Null = Start-Polaris -ErrorAction SilentlyContinue
+            Start-Sleep -Seconds 5
+            }
+        catch {}
+        }
+
+
+    It "Should create static routes for all files" {
+
+        #  Confirm expected routes created
+        $Routes = Get-WebRoute -Path $Paths -Method Get
+        $Routes.Count | Should Be $Paths.Count
+
+        #  Confirm no other routes created
+        $AllRoutes = Get-WebRoute
+        $AllRoutes.Count | Should Be $Paths.Count
+        }
+
+    It "Should create routes that serve files" {
+
+        #  Confirm file can be downloaded
+        $Download = Invoke-WebRequest -Uri $File1Uri -TimeoutSec 10
+        $Download.Content | Should be $File1Content
+        }
+
+    It "Should throw error if route for file exists" {
+
+        #  Start with a clean slate
+        Remove-WebRoute
+
+        #  Create a route which will conflict with next command
+        New-WebRoute -Path $Paths[0] -Method GET -ScriptBlock {'Existing script'}
+
+        #  Create static routes
+        New-StaticRoute -RoutePath 'BaseRoot' -FolderPath $TestPath | Should throw
+        }
+
+    It "Should overwrite matching route with Force switch" {
+
+        #  Start with a clean slate
+        Remove-WebRoute
+
+        #  Create a route which will conflict with next command
+        New-WebRoute -Path $Paths[0] -Method GET -ScriptBlock {'Existing script'}
+
+        #  Create static routes
+        New-StaticRoute -RoutePath 'BaseRoot' -FolderPath $TestPath -Force
+
+        #  Confirm expected routes created
+        $Routes = Get-WebRoute -Path $Paths -Method Get
+        $Routes.Count | Should Be 4
+
+        #  Confirm conflicting route was overwritten
+        $NewRoute = Get-WebRoute $Paths[0] -Method GET
+        $NewRoute.ScriptBlock.TrimStart().SubString( 0, 20 ) | Should be '$bytes = Get-Content'
+        }
+
+    AfterAll {
+
+        #  Clean up test routes
+        Remove-WebRoute
+
+        #  Stop Polaris
+        Stop-Polaris
+
+        #  Clean up test folders
+        Get-ChildItem -Path $TestPath -Recurse | Remove-Item -Recurse -Force
+        Remove-Item -Path $TestPath
+        }
+    }

--- a/test/New-StaticRoute.Tests.ps1
+++ b/test/New-StaticRoute.Tests.ps1
@@ -3,16 +3,16 @@
     BeforeAll {
 
         #  Import module
-        Import-Module -Name Polaris
+        Import-Module "$PSScriptRoot\..\Polaris.psd1"
 
         #  Start with a clean slate
         Remove-WebRoute
 
         #  Create test folders
         $GUID = [string][guid]::NewGuid()
-        $TestPath   = ( New-Item -Path $Env:Temp -Name $GUID  -ItemType Directory ).FullName
-        $TestFolder = ( New-Item -Path $TestPath -Name 'Sub1' -ItemType Directory ).FullName
-        
+        $TestPath   = ( New-Item -Path 'TestDrive:\' -Name $GUID  -ItemType Directory ).FullName
+        $TestFolder = ( New-Item -Path $TestPath     -Name 'Sub1' -ItemType Directory ).FullName
+
         #  Create test files
         $File1 =  ( New-Item -Path $TestPath   -Name 'File1.txt' -ItemType File ).FullName
         $Null  =    New-Item -Path $TestPath   -Name 'File2.txt' -ItemType File
@@ -72,7 +72,8 @@
         New-WebRoute -Path $Paths[0] -Method GET -ScriptBlock {'Existing script'}
 
         #  Create static routes
-        New-StaticRoute -RoutePath 'BaseRoot' -FolderPath $TestPath | Should throw
+        { New-StaticRoute -RoutePath 'BaseRoot' -FolderPath $TestPath -ErrorAction Stop } |
+            Should Throw
         }
 
     It "Should overwrite matching route with Force switch" {
@@ -102,9 +103,5 @@
 
         #  Stop Polaris
         Stop-Polaris
-
-        #  Clean up test folders
-        Get-ChildItem -Path $TestPath -Recurse | Remove-Item -Recurse -Force
-        Remove-Item -Path $TestPath
         }
     }

--- a/test/New-StaticRoute.Tests.ps1
+++ b/test/New-StaticRoute.Tests.ps1
@@ -27,21 +27,14 @@
             'BaseRoot/Sub1/File4.txt' )
 
         #  Add content to a file
-        $File1Uri = 'http://localhost:8080/BaseRoot/File1.txt'
+        $File1Uri = 'http://localhost:9999/BaseRoot/File1.txt'
         $File1Content = 'File1Content'
         $File1Content | Out-File -FilePath $File1 -Encoding ascii -NoNewline
 
         ####  Create static routes
         New-StaticRoute -RoutePath 'BaseRoot' -FolderPath $TestPath
 
-        #  Start Polaris server
-        #  Wrapped due to ignore bugs in current version
-        try
-            {
-            $Null = Start-Polaris -ErrorAction SilentlyContinue
-            Start-Sleep -Seconds 5
-            }
-        catch {}
+        Start-Polaris -Port 9999
         }
 
 

--- a/test/New-StaticRoute.Tests.ps1
+++ b/test/New-StaticRoute.Tests.ps1
@@ -3,7 +3,7 @@
     BeforeAll {
 
         #  Import module
-        Import-Module "$PSScriptRoot\..\Polaris.psd1"
+        Import-Module ..\Polaris.psd1
 
         #  Start with a clean slate
         Remove-WebRoute

--- a/test/New-WebRoute.Tests.ps1
+++ b/test/New-WebRoute.Tests.ps1
@@ -3,12 +3,8 @@
     BeforeAll {
 
         #  Import module
-        Import-Module -Name Polaris
+        Import-Module "$PSScriptRoot\..\Polaris.psd1"
 
-        #  Create 
-        $GUID = [string][guid]::NewGuid()
-        $TestPath = ( New-Item -Path $Env:Temp -Name $GUID -ItemType Directory ).FullName
-        
         #  Start with a clean slate
         Remove-WebRoute
         }
@@ -74,7 +70,7 @@
         #  Define route
         $Method = 'GET'
         $Path   = "TestScriptBlockRoute$Method"
-        $ScriptPath = "$TestPath\$Path.ps1"
+        $ScriptPath = "TestDrive:\$Path.ps1"
 
         $Path | Out-File -FilePath $ScriptPath -NoNewline
 
@@ -90,10 +86,11 @@
         #  Define route
         $Method = 'GET'
         $Path   = "TestScriptBlockRoute$Method"
-        $ScriptPath = "$TestPath\DOESNOTEXIST.ps1"
+        $ScriptPath = "TestDrive:\DOESNOTEXIST.ps1"
 
         #  Create route
-        New-WebRoute -Path $Path -Method $Method -ScriptPath $ScriptPath | Should Throw
+        { New-WebRoute -Path $Path -Method $Method -ScriptPath $ScriptPath -ErrorAction Stop } |
+            Should Throw
         }
 
     It "Should create route with matching Path but new Method" {
@@ -128,7 +125,8 @@
         New-WebRoute -Path $Path -Method $Method -ScriptBlock $Scriptblock
 
         #  Create route
-        New-WebRoute -Path $Path -Method $Method -ScriptBlock $Scriptblock | Should Throw
+        { New-WebRoute -Path $Path -Method $Method -ScriptBlock $Scriptblock -ErrorAction Stop } |
+            Should Throw
         }
 
     It "Should overwrite route with matching Path and Method with Force switch" {
@@ -153,9 +151,5 @@
 
         #  Clean up test routes
         Remove-WebRoute
-
-        #  Clean up test files
-        Get-ChildItem -Path $TestPath -Recurse | Remove-Item -Recurse -Force
-        Remove-Item -Path $TestPath
         }
     }

--- a/test/New-WebRoute.Tests.ps1
+++ b/test/New-WebRoute.Tests.ps1
@@ -1,0 +1,161 @@
+﻿Describe "New-WebRoute" {
+
+    BeforeAll {
+
+        #  Import module
+        Import-Module -Name Polaris
+
+        #  Create 
+        $GUID = [string][guid]::NewGuid()
+        $TestPath = ( New-Item -Path $Env:Temp -Name $GUID -ItemType Directory ).FullName
+        
+        #  Start with a clean slate
+        Remove-WebRoute
+        }
+
+    It "Should create GET route" {
+
+        #  Define route
+        $Method = 'GET'
+        $Path   = "TestRoute$Method"
+        $Scriptblock = [scriptblock]::Create( $Path )
+
+        #  Create route
+        New-WebRoute -Path $Path -Method $Method -ScriptBlock $Scriptblock
+        
+        #  Test route
+        ( Get-WebRoute -Path $Path -Method $Method ).Scriptblock | Should Be $Path
+        }
+
+    It "Should create POST route" {
+
+        #  Define route
+        $Method = 'POST'
+        $Path   = "TestRoute$Method"
+        $Scriptblock = [scriptblock]::Create( $Path )
+
+        #  Create route
+        New-WebRoute -Path $Path -Method $Method -ScriptBlock $Scriptblock
+        
+        #  Test route
+        ( Get-WebRoute -Path $Path -Method $Method ).Scriptblock | Should Be $Path
+        }
+
+    It "Should create PUT route" {
+
+        #  Define route
+        $Method = 'PUT'
+        $Path   = "TestRoute$Method"
+        $Scriptblock = [scriptblock]::Create( $Path )
+
+        #  Create route
+        New-WebRoute -Path $Path -Method $Method -ScriptBlock $Scriptblock
+        
+        #  Test route
+        ( Get-WebRoute -Path $Path -Method $Method ).Scriptblock | Should Be $Path
+        }
+
+    It "Should create DELETE route" {
+
+        #  Define route
+        $Method = 'DELETE'
+        $Path   = "TestRoute$Method"
+        $Scriptblock = [scriptblock]::Create( $Path )
+
+        #  Create route
+        New-WebRoute -Path $Path -Method $Method -ScriptBlock $Scriptblock
+        
+        #  Test route
+        ( Get-WebRoute -Path $Path -Method $Method ).Scriptblock | Should Be $Path
+        }
+
+    It "Should create route with Scriptpath" {
+
+        #  Define route
+        $Method = 'GET'
+        $Path   = "TestScriptBlockRoute$Method"
+        $ScriptPath = "$TestPath\$Path.ps1"
+
+        $Path | Out-File -FilePath $ScriptPath -NoNewline
+
+        #  Create route
+        New-WebRoute -Path $Path -Method $Method -ScriptPath $ScriptPath
+        
+        #  Test route
+        ( Get-WebRoute -Path $Path -Method $Method ).Scriptblock | Should Be $Path
+        }
+
+    It "Should throw error if Scriptpath not found" {
+
+        #  Define route
+        $Method = 'GET'
+        $Path   = "TestScriptBlockRoute$Method"
+        $ScriptPath = "$TestPath\DOESNOTEXIST.ps1"
+
+        #  Create route
+        New-WebRoute -Path $Path -Method $Method -ScriptPath $ScriptPath | Should Throw
+        }
+
+    It "Should create route with matching Path but new Method" {
+
+        #  Define route
+        $Method = 'GET'
+        $Path   = "TestNewMethod$Method"
+        $Scriptblock = [scriptblock]::Create( $Path )
+
+        #  Create route
+        New-WebRoute -Path $Path -Method $Method -ScriptBlock $Scriptblock
+
+        #  Define route
+        $Method = 'POST'
+        $Scriptblock = [scriptblock]::Create( $Path )
+
+        #  Create route
+        New-WebRoute -Path $Path -Method $Method -ScriptBlock $Scriptblock
+
+        #  Test route
+        ( Get-WebRoute -Path $Path -Method $Method ).Scriptblock | Should Be $Path
+        }
+
+    It "Should throw error if route for Path and Method exists" {
+
+        #  Define route
+        $Method = 'GET'
+        $Path   = "TestExisting"
+        $Scriptblock = [scriptblock]::Create( $Path )
+
+        #  Create route
+        New-WebRoute -Path $Path -Method $Method -ScriptBlock $Scriptblock
+
+        #  Create route
+        New-WebRoute -Path $Path -Method $Method -ScriptBlock $Scriptblock | Should Throw
+        }
+
+    It "Should overwrite route with matching Path and Method with Force switch" {
+
+        #  (Using existing route from previous test.)
+
+        #  Define route
+        $Method = 'GET'
+        $Path   = "TestExisting"
+        $NewContent = "NewContent"
+        $Scriptblock = [scriptblock]::Create( $NewContent )
+
+        #  Create route
+        New-WebRoute -Path $Path -Method $Method -ScriptBlock $Scriptblock -Force
+
+        
+        #  Test route
+        ( Get-WebRoute -Path $Path -Method $Method ).Scriptblock | Should Be $NewContent
+        }
+
+    AfterAll {
+
+        #  Clean up test routes
+        Remove-WebRoute
+
+        #  Clean up test files
+        Get-ChildItem -Path $TestPath -Recurse | Remove-Item -Recurse -Force
+        Remove-Item -Path $TestPath
+        }
+    }

--- a/test/New-WebRoute.Tests.ps1
+++ b/test/New-WebRoute.Tests.ps1
@@ -3,7 +3,7 @@
     BeforeAll {
 
         #  Import module
-        Import-Module "$PSScriptRoot\..\Polaris.psd1"
+        Import-Module ..\Polaris.psd1
 
         #  Start with a clean slate
         Remove-WebRoute

--- a/test/PolarisRoute.Tests.ps1
+++ b/test/PolarisRoute.Tests.ps1
@@ -120,7 +120,8 @@ Describe "Test route creation" {
 
     Context "Using Get-WebRoute and Remove-WebRoute" {
         It "Will get the object with the routes" {
-            (Get-WebRoute)["test"]["GET"] | Should Be $defaultScriptBlock.ToString()
+            ( Get-WebRoute -Path "/test" -Method "GET" ).ScriptBlock |
+                Should Be $defaultScriptBlock.ToString()
         }
         It "will remove the routes" {
             Remove-WebRoute -Path "/test" -Method "GET"

--- a/test/PolarisServer.Tests.ps1
+++ b/test/PolarisServer.Tests.ps1
@@ -80,9 +80,9 @@ Hello World"
         BeforeAll {
             if (-not $IsUnix) {
                 Stop-Polaris
-                Start-Polaris -Port $Port
+                Start-Polaris -Port 9998
     
-                $result = Invoke-WebRequest -Uri "http://localhost:$Port/helloworld"
+                $result = Invoke-WebRequest -Uri "http://localhost:9998/helloworld"
                 $result.StatusCode | Should Be 200
             }
         }
@@ -90,7 +90,7 @@ Hello World"
         It "Can properly shut down the server" {
             Stop-Polaris
 
-            { Invoke-WebRequest -Uri "http://localhost:$Port/helloworld" } | Should Throw
+            { Invoke-WebRequest -Uri "http://localhost:9998/helloworld" } | Should Throw
         } -Skip:$IsUnix
     }
 }

--- a/test/Remove-RouteMiddleware.Tests.ps1
+++ b/test/Remove-RouteMiddleware.Tests.ps1
@@ -1,0 +1,125 @@
+﻿Describe "Remove-RouteMiddleware" {
+
+    BeforeAll {
+
+        #  Import Module
+        Import-Module -Name Polaris
+
+        #  Define test function to reduce redundancy
+        function Test-RemoveMiddleware ( [string[]]$Name )
+            {
+            #  Get before state
+            $MiddlewareBefore   = Get-RouteMiddleware
+            $MiddlewareToDelete = @( Get-RouteMiddleware -Name $Name )
+            $MiddlewareExpectedAfter = $MiddlewareBefore.Count - $MiddlewareToDelete.Count
+
+            #  Remove
+            Remove-RouteMiddleware -Name $Name
+
+            #  Get after state
+            $DeletedMiddlewareRemaining = $MiddlewareToDelete | Get-RouteMiddleware
+            $TotalRemainingMiddleware   = Get-RouteMiddleware
+
+            #  Test after state
+            $DeletedMiddlewareRemaining.Count | Should Be 0
+            $TotalRemainingMiddleware.Count   | Should Be $MiddlewareExpectedAfter
+            }
+
+        #  Start with a clean slate
+        Remove-RouteMiddleware
+
+        #  Create middleware to test against
+        New-RouteMiddleware -Name 'Test0'  -ScriptBlock {}
+        New-RouteMiddleware -Name 'Test1'  -ScriptBlock {}
+        New-RouteMiddleware -Name 'Test2A' -ScriptBlock {}
+        New-RouteMiddleware -Name 'Test2B' -ScriptBlock {}
+        New-RouteMiddleware -Name 'Test3A' -ScriptBlock {}
+        New-RouteMiddleware -Name 'Test3B' -ScriptBlock {}
+        New-RouteMiddleware -Name 'Test3C' -ScriptBlock {}
+        New-RouteMiddleware -Name 'Test4A' -ScriptBlock {}
+        New-RouteMiddleware -Name 'Test4B' -ScriptBlock {}
+        New-RouteMiddleware -Name 'Test5A' -ScriptBlock {}
+        New-RouteMiddleware -Name 'Test5B' -ScriptBlock {}
+        New-RouteMiddleware -Name 'Test6'  -ScriptBlock {}
+        }
+
+    It "Should delete middleware" {
+        
+        Test-RemoveMiddleware -Name 'Test1'
+        }
+
+    It "Should do nothing when no middleware match" {
+        
+        Test-RemoveMiddleware -Name 'DoesNotExist'
+        }
+
+    It "Should accept multiple values for Name" {
+
+        Test-RemoveMiddleware -Name 'Test2A', 'Test2B'
+        }
+
+    It "Should accept wildcard values for Name" {
+
+        Test-RemoveMiddleware -Name 'Test3*'
+        }
+
+    It "Should accept Name from pipeline" {
+
+        $Name = 'Test4A', 'Test4B'
+
+        #  Get before state
+        $MiddlewareBefore   = Get-RouteMiddleware
+        $MiddlewareToDelete = @( Get-RouteMiddleware -Name $Name )
+        $MiddlewareExpectedAfter = $MiddlewareBefore.Count - $MiddlewareToDelete.Count
+
+        #  Remove
+        $Name | Remove-RouteMiddleware
+
+        #  Get after state
+        $DeletedMiddlewareRemaining = $MiddlewareToDelete | Get-RouteMiddleware
+        $TotalRemainingMiddleware   = Get-RouteMiddleware
+
+        #  Test after state
+        $DeletedMiddlewareRemaining.Count | Should Be 0
+        $TotalRemainingMiddleware.Count   | Should Be $MiddlewareExpectedAfter
+        }
+
+    It "Should accept Name from pipeline variables" {
+
+        $Name = 'Test5*'
+
+        #  Get before state
+        $MiddlewareBefore   = Get-RouteMiddleware
+        $MiddlewareToDelete = @( Get-RouteMiddleware -Name $Name )
+        $MiddlewareExpectedAfter = $MiddlewareBefore.Count - $MiddlewareToDelete.Count
+
+        #  Remove
+        $MiddlewareToDelete | Remove-RouteMiddleware
+
+        #  Get after state
+        $DeletedMiddlewareRemaining = $MiddlewareToDelete | Get-RouteMiddleware
+        $TotalRemainingMiddleware   = Get-RouteMiddleware
+
+        #  Test after state
+        $DeletedMiddlewareRemaining.Count | Should Be 0
+        $TotalRemainingMiddleware.Count   | Should Be $MiddlewareExpectedAfter
+        }
+
+    It "Should delete all middleware if no Name parameter" {
+
+        #  Remove
+        Remove-RouteMiddleware
+
+        #  Get after state
+        $TotalRemainingMiddleware = Get-RouteMiddleware
+
+        #  Test after state
+        $TotalRemainingMiddleware.Count | Should Be 0
+        }
+
+    AfterAll {
+
+        #  Clean up test middleware
+        Remove-RouteMiddleware
+        }
+    }

--- a/test/Remove-RouteMiddleware.Tests.ps1
+++ b/test/Remove-RouteMiddleware.Tests.ps1
@@ -3,7 +3,7 @@
     BeforeAll {
 
         #  Import Module
-        Import-Module "$PSScriptRoot\..\Polaris.psd1"
+        Import-Module ..\Polaris.psd1
 
         #  Define test function to reduce redundancy
         function Test-RemoveMiddleware

--- a/test/Remove-WebRoute.Tests.ps1
+++ b/test/Remove-WebRoute.Tests.ps1
@@ -1,0 +1,118 @@
+﻿Describe "Remove-WebRoute" {
+
+    BeforeAll {
+        
+        #  Import module
+        Import-Module -Name Polaris
+
+        #  Define test function to reduce redundancy
+        function Test-RemoveRoute ( [string[]]$Path, [string[]]$Method )
+            {
+            #  Get before state
+            $RoutesBefore   = Get-WebRoute
+            $RoutesToDelete = @( Get-WebRoute -Path $Path -Method $Method )
+            $RoutesExpectedAfter = $RoutesBefore.Count - $RoutesToDelete.Count
+
+            #  Remove
+            Remove-WebRoute -Path $Path -Method $Method
+
+            #  Get after state
+            $DeletedRoutesRemaining = $RoutesToDelete | Get-WebRoute
+            $TotalRemainingRoutes   = Get-WebRoute
+
+            #  Test after state
+            $DeletedRoutesRemaining.Count | Should Be 0
+            $TotalRemainingRoutes.Count   | Should Be $RoutesExpectedAfter
+            }
+
+        #  Start with a clean slate
+        Remove-WebRoute
+
+        #  Create some web routes to test against
+        New-WebRoute -Path 'Test0'  -Method GET  -ScriptBlock {}
+        New-WebRoute -Path 'Test0'  -Method POST -ScriptBlock {}
+        New-WebRoute -Path 'Test1'  -Method GET  -ScriptBlock {}
+        New-WebRoute -Path 'Test2'  -Method GET  -ScriptBlock {}
+        New-WebRoute -Path 'Test2'  -Method POST -ScriptBlock {}
+        New-WebRoute -Path 'Test3A' -Method PUT  -ScriptBlock {}
+        New-WebRoute -Path 'Test3B' -Method PUT  -ScriptBlock {}
+        New-WebRoute -Path 'Test3C' -Method GET  -ScriptBlock {}
+        New-WebRoute -Path 'Test4A' -Method PUT  -ScriptBlock {}
+        New-WebRoute -Path 'Test4B' -Method PUT  -ScriptBlock {}
+        New-WebRoute -Path 'Test5'  -Method GET  -ScriptBlock {}
+        New-WebRoute -Path 'Test5'  -Method POST -ScriptBlock {}
+        New-WebRoute -Path 'Test5'  -Method PUT  -ScriptBlock {}
+        New-WebRoute -Path 'Test6A' -Method GET  -ScriptBlock {}
+        New-WebRoute -Path 'Test6B' -Method GET  -ScriptBlock {}
+        New-WebRoute -Path 'Test7A' -Method GET  -ScriptBlock {}
+        New-WebRoute -Path 'Test7B' -Method GET  -ScriptBlock {}
+        }
+
+    It "Should delete route" {
+        Test-RemoveRoute -Path 'Test1' -Method 'GET'
+        }
+
+    It "Should respect Path" {
+        Test-RemoveRoute -Path 'Test2' -Method '*'
+        }
+
+    It "Should respect Method" {
+        Test-RemoveRoute -Path 'Test3*' -Method 'PUT'
+        }
+
+    It "Should do nothing when no routes match" {
+        Test-RemoveRoute -Path 'DOESNOTEXIST' -Method 'PUT'
+        }
+
+    It "Should accept multiple values for Path" {
+        Test-RemoveRoute -Path 'Test4A', 'Test4B' -Method 'GET'
+        }
+
+    It "Should accept multiple values for Method" {
+        Test-RemoveRoute -Path 'Test5' -Method 'GET', 'POST'
+        }
+
+    It "Should accept Path from pipeline" {
+
+        #  Get before state
+        $RoutesBefore   = Get-WebRoute
+        $RoutesToDelete = @( Get-WebRoute -Path 'Test6A', 'Test6B' )
+        $RoutesExpectedAfter = $RoutesBefore.Count - $RoutesToDelete.Count
+
+        #  Remove
+        'Test6A', 'Test6B' | Remove-WebRoute
+
+        #  Get after state
+        $DeletedRoutesRemaining = $RoutesToDelete | Get-WebRoute
+        $TotalRemainingRoutes   = Get-WebRoute
+
+        #  Test after state
+        $DeletedRoutesRemaining.Count | Should Be 0
+        $TotalRemainingRoutes.Count   | Should Be $RoutesExpectedAfter
+        }
+
+    It "Should accept Path and Method from pipeline variables" {
+
+        #  Get before state
+        $RoutesBefore   = Get-WebRoute
+        $RoutesToDelete = @( Get-WebRoute -Path 'Test7A', 'Test7B' )
+        $RoutesExpectedAfter = $RoutesBefore.Count - $RoutesToDelete.Count
+
+        #  Remove
+        $RoutesToDelete | Remove-WebRoute
+
+        #  Get after state
+        $DeletedRoutesRemaining = $RoutesToDelete | Get-WebRoute
+        $TotalRemainingRoutes   = Get-WebRoute
+
+        #  Test after state
+        $DeletedRoutesRemaining.Count | Should Be 0
+        $TotalRemainingRoutes.Count   | Should Be $RoutesExpectedAfter
+        }
+
+    AfterAll {
+
+        #  Clean up any test routes
+        Remove-WebRoute
+        }
+    }

--- a/test/Remove-WebRoute.Tests.ps1
+++ b/test/Remove-WebRoute.Tests.ps1
@@ -3,7 +3,7 @@
     BeforeAll {
         
         #  Import module
-        Import-Module "$PSScriptRoot\..\Polaris.psd1"
+        Import-Module ..\Polaris.psd1
 
         #  Define test function to reduce redundancy
         function Test-RemoveRoute


### PR DESCRIPTION
Breaking change - Output of Get-WebRoute changed from dictionary to array of psobjects.

Other changes
1.	Polaris.psm1
a.	Removed unnecessary $m variable creation. (It isn’t used again.)
b.	.Module.OnRemove
i.	Added -ErrorAction to ignore existing bugs.
c.	New-WebRoute
i.	Updated help.
ii.	Simplified If conditional.
iii.	Added whitespace for improved readability.
iv.	Added validation set for parameter -Method.
v.	Mandatory = $True to parameters -ScriptBlock and -ScriptPath.
vi.	Added parameter sets ScriptBlock and ScriptPath.
vii.	Added handling to make leading solidus (/) optional.
viii.	Removed unnecessary and/or redundant conversions of $Scriptblock from string to scriptblock and back to string.
ix.	Replaced ThrowError with $PSCmdlet.WriteError. (ThrowError creates a dependency on the DSC module.)
x.	Added -Force switch. Added check for existing web route. (-Force causes overwrite, else non-terminating error.)
d.	Remove-WebRoute
i.	Updated help.
ii.	Simplified If conditional.
iii.	Added whitespace for improved readability.
iv.	Removed redundant positional parameter specifications (Parameters are positional by default if no parameter sets defined.)
v.	Removed Mandatory from parameters -Path and -Method.
vi.	Added handling for pipeline input, multiple values, and wildcard values.
e.	Get-WebRoute
i.	Updated help.
ii.	Simplified If conditional.
iii.	Added whitespace for improved readability.
iv.	Added conversion of dictionary to expanded psobjects, with Path, Method, and Scriptblock properties. – Breaking change
v.	Added optional parameters Path, Method. Each can take multiple values and PowerShell wildcards. Each defaults to ‘*’.
vi.	Added handling for pipeline input.
f.	New-StaticRoute
i.	Updated help.
ii.	Added whitespace for improved readability.
iii.	Removed redundant positional parameter specifications (Parameters are positional by default if no parameter sets defined.)
iv.	Moved $RoutePath.TrimEnd() out of loop to improve efficiency.
v.	Moved PowerShell version logic out of script template to simplify and improve efficiency of the route scriptblock.
vi.	Added parameter switch -Force. Value is passed through to New-WebRoute.
g.	New-RouteMiddleware
i.	Updated help.
ii.	Simplified If conditional.
iii.	Added whitespace for improved readability.
iv.	Added parameters sets ScriptBlock and ScriptPath.
v.	Removed unnecessary and/or redundant conversion of $Scriptblock from string to scriptblock and back to string.
vi.	Replaced ThrowError with $PSCmdlet.WriteError. (ThrowError creates a dependency on the DSC module.)
vii.	Added -Force switch. Added check for existing route middleware. (-Force causes overwrite, else non-terminating error.)
h.	Remove-RouteMiddleWare
i.	Updated help.
ii.	Simplified If conditional.
iii.	Added whitespace for improved readability.
iv.	Removed redundant positional parameter specification. (Parameters are positional by default if no parameter sets defined.)
v.	Removed Mandatory from parameter -Name.
vi.	Added handling for pipeline input, multiple values, and wildcard values.
i.	Get-RouteMiddleware
i.	Updated help.
ii.	Simplified If conditional.
iii.	Added whitespace for improved readability.
iv.	Removed redundant positional parameter specification.
v.	Set default parameter -Name value to ‘*’.
vi.	Added handling for parameter -Name wildcard values and multiple values.
vii.	Added handling for pipeline input.
j.	Start-Polaris
i.	Updated help.
ii.	Added whitespace for improved readability.
iii.	Removed redundant positional parameter specifications (Parameters are positional by default if no parameter sets defined.)
k.	Stop-Polaris
i.	Updated help.
ii.	Simplified If conditional.
iii.	Added whitespace for improved readability.
iv.	Removed redundant positional parameter specifications (Parameters are positional by default if no parameter sets defined.)
v.	Removed redundant check if $ServerContext is null. ($ServerContext can never be null.)
vi.	Removed try/catch which always fails.
l.	New-GetRoute
i.	Updated help.
ii.	Added whitespace for improved readability.
iii.	Added Mandatory = $True to parameters $ScriptBlock and $ScriptPath.
iv.	Added handling for new parameter sets on New-WebRoute.
v.	Added -Force switch. Value is passed to New-WebRoute.
m.	New-PostRoute
i.	Updated help.
ii.	Added whitespace for improved readability.
iii.	Added Mandatory = $True to parameters $ScriptBlock and $ScriptPath.
iv.	Added handling for new parameter sets on New-WebRoute.
v.	Added -Force switch. Value is passed to New-WebRoute.
n.	New-PutRoute
i.	Updated help.
ii.	Added whitespace for improved readability.
iii.	Added Mandatory = $True to parameters $ScriptBlock and $ScriptPath.
iv.	Added handling for new parameter sets on New-WebRoute.
v.	Added -Force switch. Value is passed to New-WebRoute.
o.	New-DeleteRoute
i.	Updated help.
ii.	Added whitespace for improved readability.
iii.	Added Mandatory = $True to parameters $ScriptBlock and $ScriptPath.
iv.	Added handling for new parameter sets on New-WebRoute.
v.	Removed redundant CreateNewPolarisIfNeeded. (It’s called within New-WebRoute.)
p.	Use-JsonBodyParserMiddleware
i.	Updated help.
ii.	Added -Force to New-RouteMiddleware
q.	CreateNewPolarisIfNeeded
i.	Simplified If conditional.
ii.	Simplified object creation.
iii.	Added whitespace for improved readability.
r.	Export-ModuleMember
i.	Removed redundant line continuations. (Line break okay after comma.)
2.	Polaris.psd1
a.	Set FunctionToExport to equal ‘*’. (Defined in .psm1.)
3.	/Tests
a.	Added Pester test files.
i.	New-WebRoute.Tests.ps1
ii.	Remove-WebRoute.Tests.ps1
iii.	Get-WebRoute.Tests.ps1
iv.	New-StatisRoute.Tests.ps1
v.	New-RouteMiddleware.Tests.ps1
vi.	Remove-RouteMiddleware.Tests.ps1
vii.	Get-RouteMiddleware.Tests.ps1
viii.	Helpers.Tests.ps1
