### PR TITLE
Add `Install-Module Pester`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - dotnet restore
   - dotnet build -f netstandard2.0
   - popd && pushd test
-  - sudo pwsh -c 'Install-Module Pester; Invoke-Pester -ExcludeTag VersionChecks -EnableExit'
+  - sudo pwsh ./build/travis.ps1
   - popd
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - dotnet restore
   - dotnet build -f netstandard2.0
   - popd && pushd test
-  - pwsh -c 'Install-Module Pester; Invoke-Pester -ExcludeTag VersionChecks -EnableExit'
+  - sudo pwsh -c 'Install-Module Pester; Invoke-Pester -ExcludeTag VersionChecks -EnableExit'
   - popd
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,8 @@ script:
   - pushd PolarisCore
   - dotnet restore
   - dotnet build -f netstandard2.0
-  - popd && pushd test
-  - sudo pwsh ./build/travis.ps1
   - popd
+  - sudo pwsh ./build/travis.ps1
 notifications:
   webhooks:
     urls:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - dotnet restore
   - dotnet build -f netstandard2.0
   - popd && pushd test
-  - pwsh -c 'Invoke-Pester -ExcludeTag VersionChecks -EnableExit'
+  - pwsh -c 'Install-Module Pester; Invoke-Pester -ExcludeTag VersionChecks -EnableExit'
   - popd
 notifications:
   webhooks:

--- a/build/travis.ps1
+++ b/build/travis.ps1
@@ -1,0 +1,3 @@
+Set-PSRepository -Name "PSGallery" -InstallationPolicy Trusted
+Install-Module Pester
+Invoke-Pester -ExcludeTag VersionChecks -EnableExit

--- a/build/travis.ps1
+++ b/build/travis.ps1
@@ -1,3 +1,5 @@
 Set-PSRepository -Name "PSGallery" -InstallationPolicy Trusted
 Install-Module Pester
+pushd test
 Invoke-Pester -ExcludeTag VersionChecks -EnableExit
+popd


### PR DESCRIPTION
PSCore removed Pester as a dependency now. We can use the new version of Pester that supports PSCore.