### PR TITLE
Updated gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -301,3 +301,6 @@ __pycache__/
 
 # Pester output
 test/TestsResults.xml
+
+# Running a build can create a .dotnet directory in the project and we don't want to commit that
+.dotnet/


### PR DESCRIPTION
When running the build the the system can make a .dotnet directory in the
project root that has a copy of the dotnet command line tools if they
weren't already installed. This change will ignore those files from the
version control.