### PR TITLE
Tidy up build task relations.

### DIFF
--- a/Polaris.build.ps1
+++ b/Polaris.build.ps1
@@ -7,7 +7,7 @@ if ($PSVersionTable.PSEdition -ne "Core") {
     Add-Type -Assembly System.IO.Compression.FileSystem
 }
 
-task SetupDotNet -Before Restore, Build, Clean, Test {
+task SetupDotNet {
 
     $requiredSdkVersion = "2.0.0"
 
@@ -79,15 +79,15 @@ function NeedsRestore($rootPath) {
     return ($projectAssets -eq $null) -or ((Get-ChildItem $rootPath).Length -gt $projectAssets.Length)
 }
 
-task Restore -If { "Restore" -in $BuildTask -or (NeedsRestore(".\PolarisCore")) } -Before Clean, Build, Test {
+task Restore -If { "Restore" -in $BuildTask -or (NeedsRestore(".\PolarisCore")) } SetupDotNet, {
     exec { & $script:dotnetExe restore .\PolarisCore\Polaris.csproj }
 }
 
-task Clean {
+task Clean Restore, {
     exec { & $script:dotnetExe clean .\PolarisCore\Polaris.csproj }
 }
 
-task Build {
+task Build Restore, {
     if (!$script:IsUnix) {
         exec { & $script:dotnetExe build .\PolarisCore\Polaris.csproj -f net451 }
         Write-Host "" # Newline

--- a/Polaris.build.ps1
+++ b/Polaris.build.ps1
@@ -96,7 +96,7 @@ task Build Restore, {
     exec { & $script:dotnetExe build .\PolarisCore\Polaris.csproj -f netstandard2.0 }
 }
 
-task Test {
+task Test Build, {
     # TODO: Add tests
     if ($PSVersionTable.PSEdition -ne "Core") {
         Install-Module Pester -Force -Scope CurrentUser


### PR DESCRIPTION
There is nothing wrong with the current script but the task relations are more
complex than they can be. Maybe use of not recommended `-Before` is the reason.
`-Before` and `-After` are designed for cases when we do not own a build script.

The PR defines the same relations in the normal way using `-Jobs`.

Here are the task graphs generated by `Show-BuildGraph.ps1`

After the change:

![image](https://user-images.githubusercontent.com/927533/34470242-622b9a66-ef25-11e7-9aa9-ebd67421aae2.png)

Before the change:

![image](https://user-images.githubusercontent.com/927533/34470245-728ddf4a-ef25-11e7-8f86-4d60f73994df.png)
