### PR TITLE
Example code was failing - small fix to make it work as expected

### DIFF
--- a/example/example.ps1
+++ b/example/example.ps1
@@ -13,8 +13,8 @@ New-PolarisRoute -Path /helloworld -Method GET -ScriptBlock {
 
 # Query Parameters are supported
 New-PolarisRoute -Path /hellome -Method GET -ScriptBlock {
-    if ($request.QueryParameters['name']) {
-        $response.Send('Hello ' + $request.QueryParameters['name'])
+    if ($request.Query['name']) {
+        $response.Send('Hello ' + $request.Query['name'])
     } else {
         $response.Send('Hello World')
     }

--- a/test/PolarisServer.Tests.ps1
+++ b/test/PolarisServer.Tests.ps1
@@ -19,7 +19,7 @@ Describe "Test webserver use" {
         }
 
 
-        It "test /header router" {
+        It "test /header route" {
             $result = Invoke-WebRequest -Uri "http://localhost:$Port/header"
             $result.Content | Should Be 'Header test'
             $result.StatusCode | Should Be 200

--- a/test/PolarisServer.ps1
+++ b/test/PolarisServer.ps1
@@ -1,9 +1,4 @@
 
-# Support Headers
-New-PolarisRoute -Path /header -Method "GET" -ScriptBlock {
-    $response.SetHeader('Location','http://www.contoso.com/');
-    $response.Send("Header test");
-}
 if(-not (Test-Path -Path ..\Polaris.psm1)) {
     Write-Error -Message "Cannot find Polaris.psm1"
     return


### PR DESCRIPTION
While trying out the module I had hard time with `/hellome` example - after looking into tests I realized that the way query parameters are accessed in the example and test code are different.

In this PR I simply make examples in sync with the code used in tests.

On top of that I noticed errors in server definition used in tests - it had part with `/headers` duplicated, removed one of appearances to avoid confusing error in test output.