### PR TITLE
Better check for timeoutManager api

### DIFF
--- a/lib/Polaris.Class.ps1
+++ b/lib/Polaris.Class.ps1
@@ -246,7 +246,7 @@ class Polaris {
         }
 
         $this.Listener.IgnoreWriteExceptions = $true
-        if([System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT){
+        if($this.Listener | Get-Member -Name TimeoutManager){
             $this.Listener.TimeoutManager.RequestQueue = [timespan]::FromMinutes(5)
             $this.Listener.TimeoutManager.IdleConnection = [timespan]::FromSeconds(45)
             $this.Listener.TimeoutManager.EntityBody = [timespan]::FromSeconds(50)


### PR DESCRIPTION
The previous check was attempting to check if timeoutmanager is available on the object by determining the OS architecture. I assumed if you were Linux, you were using .net core which meant your version of HttpListener did not contain the timeoutmanager.

Flawed logic... Now I am just checking to see if the member exists and if it does we use it.

Should resolve issue #124 