### PR TITLE
Remove System.Web from RequiredAssemblies

### DIFF
--- a/Polaris.psd1
+++ b/Polaris.psd1
@@ -54,7 +54,7 @@
     # RequiredModules = @()
     
     # Assemblies that must be loaded prior to importing this module
-    RequiredAssemblies = @("System.Web")
+    RequiredAssemblies = @()
     
     # Script files (.ps1) that are run in the caller's environment prior to importing this module.
     ScriptsToProcess   = @(


### PR DESCRIPTION
This is a blocker to ship on the Gallery:

```
Microsoft.PowerShell.Core\Test-ModuleManifest : The specified RequiredAssemblies entry 'System.Web' in the module manifest '/var/folders/rg/g30_83v14m10px9z72kydv1m0000gn/T/1727029690/Polaris/Polaris.psd1' is invalid. Try again after updating this entry with valid values.
```