### PR TITLE
Fixes #134 regex routes

### DIFF
--- a/Polaris.psd1
+++ b/Polaris.psd1
@@ -44,17 +44,6 @@
     # Modules that must be imported into the global environment prior to importing this module
     # RequiredModules = @()
     
-    # Script files (.ps1) that are run in the caller's environment prior to importing this module.
-    ScriptsToProcess     = @(
-        "Public\New-ScriptblockCallback.ps1",
-        "lib\MimeTypes.Class.ps1",
-        "lib\PolarisRequest.Class.ps1",
-        "lib\PolarisResponse.Class.ps1",
-        "lib\PolarisMiddleware.Class.ps1",
-        "lib\PolarisRoute.Class.ps1",
-        "lib\Polaris.Class.ps1"
-    )
-    
     # Type files (.ps1xml) to be loaded when importing this module
     # TypesToProcess = @()
     

--- a/Polaris.psd1
+++ b/Polaris.psd1
@@ -9,31 +9,31 @@
 @{
 
     # Script module or binary module file associated with this manifest.
-    RootModule = "Polaris.psm1"
+    RootModule           = "Polaris.psm1"
     
     # Version number of this module.
-    ModuleVersion = '0.2.0'
+    ModuleVersion        = '0.2.0'
     
     # Supported PSEditions
     CompatiblePSEditions = @('Desktop', 'Core')
     
     # ID used to uniquely identify this module
-    GUID = 'd9c86d71-cda6-431e-b297-34e0560f8e30'
+    GUID                 = 'd9c86d71-cda6-431e-b297-34e0560f8e30'
     
     # Author of this module
-    Author = 'Microsoft Corporation'
+    Author               = 'Microsoft Corporation'
     
     # Company or vendor of this module
-    CompanyName = 'Microsoft Corporation'
+    CompanyName          = 'Microsoft Corporation'
     
     # Copyright statement for this module
-    Copyright = '© Microsoft Corporation. All rights reserved'
+    Copyright            = '© Microsoft Corporation. All rights reserved'
     
     # Description of the functionality provided by this module
-    Description = 'A cross-platform, minimalist web framework for PowerShell'
+    Description          = 'A cross-platform, minimalist web framework for PowerShell'
     
     # Minimum version of the Windows PowerShell engine required by this module
-    PowerShellVersion = '5.1'
+    PowerShellVersion    = '5.1'
     
     # Minimum version of the common language runtime (CLR) required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
     # CLRVersion = ''
@@ -45,12 +45,13 @@
     # RequiredModules = @()
     
     # Script files (.ps1) that are run in the caller's environment prior to importing this module.
-    ScriptsToProcess   = @(
+    ScriptsToProcess     = @(
         "Public\New-ScriptblockCallback.ps1",
         "lib\MimeTypes.Class.ps1",
         "lib\PolarisRequest.Class.ps1",
         "lib\PolarisResponse.Class.ps1",
         "lib\PolarisMiddleware.Class.ps1",
+        "lib\PolarisRoute.Class.ps1",
         "lib\Polaris.Class.ps1"
     )
     
@@ -64,7 +65,7 @@
     # NestedModules = @()
     
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-    FunctionsToExport  = @(
+    FunctionsToExport    = @(
         'Get-Polaris'
         'Clear-Polaris'
         'New-PolarisRoute'
@@ -85,13 +86,13 @@
         'Stop-Polaris' )
     
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
-    CmdletsToExport    = @()
+    CmdletsToExport      = @()
     
     # Variables to export from this module
-    VariablesToExport  = '*'
+    VariablesToExport    = '*'
     
     # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-    AliasesToExport    = '*'
+    AliasesToExport      = '*'
     
     # List of all modules packaged with this module
     # ModuleList = @()
@@ -100,18 +101,18 @@
     # FileList = @()
     
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
-    PrivateData        = @{
+    PrivateData          = @{
     
         PSData = @{
     
             # Tags applied to this module. These help with module discovery in online galleries.
-            Tags = @('web','core','framework','REST')
+            Tags         = @('web', 'core', 'framework', 'REST')
     
             # A URL to the license for this module.
-            LicenseUri = 'https://github.com/PowerShell/Polaris/blob/master/LICENSE.txt'
+            LicenseUri   = 'https://github.com/PowerShell/Polaris/blob/master/LICENSE.txt'
     
             # A URL to the main website for this project.
-            ProjectUri = 'https://github.com/PowerShell/Polaris'
+            ProjectUri   = 'https://github.com/PowerShell/Polaris'
     
             # A URL to an icon representing this module.
             # IconUri = ''

--- a/Public/Get-PolarisRoute.ps1
+++ b/Public/Get-PolarisRoute.ps1
@@ -55,7 +55,7 @@ function Get-PolarisRoute {
     
     process {
         if ( $Polaris ) {
-            $MatchingRoutes = foreach ($Pattern in $Path) { $Polaris.Routes | where { $_.Path -like "/$($Pattern.TrimStart("/"))" } }
+            $MatchingRoutes = foreach ($Pattern in $Path) { $Polaris.Routes | where { $_.Path -like $Pattern -or $_.Path -like "/$Pattern" } }
             $MatchMethodAndRoutes = foreach ($Pattern in $Method) { $MatchingRoutes | where { $_.Method -like $Pattern } }
 
             return $MatchMethodAndRoutes | Sort-Object -Property Path, Method -Unique

--- a/Public/Get-PolarisRoute.ps1
+++ b/Public/Get-PolarisRoute.ps1
@@ -55,7 +55,9 @@ function Get-PolarisRoute {
 
     process {
         if ( $Polaris ) {
-            $MatchingRoutes = foreach ($Pattern in $Path) { $Polaris.Routes | where { $_.Path -like $Pattern -or $_.Path -like "/$Pattern" } }
+            $MatchingRoutes = foreach ($Pattern in $Path) {
+                $Polaris.Routes | where { $_.Path -like $Pattern -or $_.Path -like "/$Pattern" }
+            }
             $MatchMethodAndRoutes = foreach ($Pattern in $Method) { $MatchingRoutes | where { $_.Method -like $Pattern } }
 
             return $MatchMethodAndRoutes | Sort-Object -Property Path, Method -Unique

--- a/Public/Get-PolarisRoute.ps1
+++ b/Public/Get-PolarisRoute.ps1
@@ -58,7 +58,9 @@ function Get-PolarisRoute {
             $MatchingRoutes = foreach ($Pattern in $Path) {
                 $Polaris.Routes | where { $_.Path -like $Pattern -or $_.Path -like "/$Pattern" }
             }
-            $MatchMethodAndRoutes = foreach ($Pattern in $Method) { $MatchingRoutes | where { $_.Method -like $Pattern } }
+            $MatchMethodAndRoutes = foreach ($Pattern in $Method) {
+                $MatchingRoutes | where { $_.Method -like $Pattern }
+            }
 
             return $MatchMethodAndRoutes | Sort-Object -Property Path, Method -Unique
         }

--- a/Public/New-PolarisRoute.ps1
+++ b/Public/New-PolarisRoute.ps1
@@ -49,7 +49,19 @@ function New-PolarisRoute {
         $Scriptblock,
 
         [Parameter( Mandatory = $True, ParameterSetName = 'ScriptPath' )]
-        [string]
+        [ValidateScript( {
+                if (-Not ($_ | Test-Path) ) {
+                    throw "File does not exist"
+                }
+                if (-Not ($_ | Test-Path -PathType Leaf) ) {
+                    throw "The Path argument must be a file. Folder paths are not allowed."
+                }
+                if ($_ -notmatch "\.ps1") {
+                    throw "The file specified in the path argument must be of type .ps1"
+                }
+                return $true 
+            })]
+        [System.IO.FileInfo]
         $ScriptPath,
         
         [switch]
@@ -97,18 +109,8 @@ function New-PolarisRoute {
             $Polaris.AddRoute( $Path, $Method, $Scriptblock )
         }
         'ScriptPath' {
-            if ( Test-Path -Path $ScriptPath ) {
-                $Script = Get-Content -Path $ScriptPath -Raw
-                $Polaris.AddRoute( $Path, $Method, [scriptblock]::Create($Script) )
-            }
-            else {
-                $PSCmdlet.WriteError( (
-                        New-Object -TypeName System.Management.Automation.ErrorRecord -ArgumentList @(
-                            [System.Exception]'ScriptPath not found.'
-                            $Null
-                            [System.Management.Automation.ErrorCategory]::ObjectNotFound
-                            $ScriptPath ) ) )
-            }
+            $Script = Get-Content -Path $ScriptPath -Raw
+            $Polaris.AddRoute( $Path, $Method, [scriptblock]::Create($Script) )
         }
     }
     

--- a/Public/New-PolarisRoute.ps1
+++ b/Public/New-PolarisRoute.ps1
@@ -117,5 +117,4 @@ function New-PolarisRoute {
             $Polaris.AddRoute( $Path, $Method, [scriptblock]::Create($Script) )
         }
     }
-    
 }

--- a/Public/New-PolarisRoute.ps1
+++ b/Public/New-PolarisRoute.ps1
@@ -9,7 +9,11 @@
 .DESCRIPTION
     Create web route for server to serve.
 .PARAMETER Path
-    Path (path/route/endpoint) of the web route to to be serviced.
+    The path for which the given scriptblock or script is invoked; can be any of:
+        * A string representing a path.
+        * A path pattern.
+        * A regular expression to match paths.
+    For examples, see Path examples.
 .PARAMETER Method
     HTTP verb/method to be serviced.
     Valid values are GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE
@@ -25,6 +29,16 @@
 .EXAMPLE
     New-PolarisRoute -Path "helloworld" -Method "GET" -Scriptblock { $Response.Send( 'Hello World' ) }
     To view results:
+    Start-Polaris
+    Start-Process http://localhost:8080/helloworld
+.EXAMPLE
+    New-PolarisRoute -Path "helloworld" -Method "GET" -ScriptPath D:\Scripts\Example.ps1
+    To view results, assuming default port:
+    Start-Polaris
+    Start-Process http://localhost:8080/helloworld
+.EXAMPLE
+    New-PolarisRoute -Path "helloworld" -Method "GET" -ScriptPath D:\Scripts\Example.ps1
+    To view results, assuming default port:
     Start-Polaris
     Start-Process http://localhost:8080/helloworld
 .EXAMPLE
@@ -61,7 +75,7 @@ function New-PolarisRoute {
                 }
                 return $true 
             })]
-        [System.IO.FileInfo]
+        [String]
         $ScriptPath,
         
         [switch]
@@ -100,7 +114,7 @@ function New-PolarisRoute {
         $Polaris = $Script:Polaris
     }
 
-    if ( -not $Path.StartsWith( '/' ) ) {
+    if ( $Path.GetType().Name -eq "String" -and -not $Path.StartsWith( '/' ) ) {
         $Path = '/' + $Path
     }
 

--- a/Public/New-PolarisRoute.ps1
+++ b/Public/New-PolarisRoute.ps1
@@ -104,7 +104,7 @@ function New-PolarisRoute {
         $Polaris = $Script:Polaris
     }
 
-    if ( $Path.GetType().Name -eq "String" -and -not $Path.StartsWith( '/' ) ) {
+     if ( $Path.GetType() -eq [string] -and -not $Path.StartsWith( '/' ) ) {
         $Path = '/' + $Path
     }
 

--- a/Public/New-PolarisRoute.ps1
+++ b/Public/New-PolarisRoute.ps1
@@ -104,7 +104,7 @@ function New-PolarisRoute {
         $Polaris = $Script:Polaris
     }
 
-     if ( $Path.GetType() -eq [string] -and -not $Path.StartsWith( '/' ) ) {
+     if ( $Path -is [string] -and -not $Path.StartsWith( '/' ) ) {
         $Path = '/' + $Path
     }
 

--- a/Public/New-PolarisRoute.ps1
+++ b/Public/New-PolarisRoute.ps1
@@ -36,16 +36,6 @@
     To view results, assuming default port:
     Start-Polaris
     Start-Process http://localhost:8080/helloworld
-.EXAMPLE
-    New-PolarisRoute -Path "helloworld" -Method "GET" -ScriptPath D:\Scripts\Example.ps1
-    To view results, assuming default port:
-    Start-Polaris
-    Start-Process http://localhost:8080/helloworld
-.EXAMPLE
-    New-PolarisRoute -Path "helloworld" -Method "GET" -ScriptPath D:\Scripts\Example.ps1
-    To view results, assuming default port:
-    Start-Polaris
-    Start-Process http://localhost:8080/helloworld
 #>
 function New-PolarisRoute {
     [CmdletBinding()]

--- a/Public/New-PolarisRoute.ps1
+++ b/Public/New-PolarisRoute.ps1
@@ -1,4 +1,4 @@
-#
+﻿#
 # Copyright (c) Microsoft. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #
@@ -60,12 +60,12 @@ function New-PolarisRoute {
                 if (-Not ($_ | Test-Path -PathType Leaf) ) {
                     throw "The Path argument must be a file. Folder paths are not allowed."
                 }
-                if ($_ -notmatch "\.ps1") {
+                if ([System.IO.Path]::GetExtension($_) -ne ".ps1") {
                     throw "The file specified in the path argument must be of type .ps1"
                 }
-                return $true 
+                return $true
             })]
-        [String]
+        [string]
         $ScriptPath,
 
         [switch]
@@ -77,26 +77,23 @@ function New-PolarisRoute {
     $ExistingWebRoute = Get-PolarisRoute -Path $Path -Method $Method
 
     if ( $ExistingWebRoute ) {
-        if ( $Force ) {
-            # If $Force is specified and there is an existing webroute we remove it
-            Remove-PolarisRoute -Path $Path -Method $Method
-        }
-        else {
-            # If $Force is not specified we throw a terminating error
+        if ( -not $Force ) {
             $Exception = [System.Exception]'WebRoute already exists.'
             $ErrorId = "Polaris.Webroute.RouteAlreadyExists"
             $ErrorCategory = [System.Management.Automation.ErrorCategory]::ResourceExists
             $TargetObject = "$Path,$Method"
-    
+
             $WebRouteExistsError = [System.Management.Automation.ErrorRecord]::new(
                 $Exception,
                 $ErrorId,
                 $ErrorCategory,
                 $TargetObject
             )
-    
+
             throw $WebRouteExistsError
+            # If $Force is specified and there is an existing webroute we remove it
         }
+        Remove-PolarisRoute -Path $Path -Method $Method
     }
 
     CreateNewPolarisIfNeeded
@@ -104,7 +101,7 @@ function New-PolarisRoute {
         $Polaris = $Script:Polaris
     }
 
-     if ( $Path -is [string] -and -not $Path.StartsWith( '/' ) ) {
+    if ( $Path -is [string] -and -not $Path.StartsWith( '/' ) ) {
         $Path = '/' + $Path
     }
 

--- a/Public/Remove-PolarisRoute.ps1
+++ b/Public/Remove-PolarisRoute.ps1
@@ -44,11 +44,11 @@ function Remove-PolarisRoute {
         [Parameter( ValueFromPipeline = $True,
             ValueFromPipelineByPropertyName = $True )]
         [string[]]
-        $Path = '*',
+        $Path = @('*'),
 
         [Parameter( ValueFromPipelineByPropertyName = $True )]
         [string[]]
-        $Method = '*',
+        $Method = @('*'),
 
         
         $Polaris = $Script:Polaris

--- a/Public/Use-PolarisJsonBodyParserMiddleware.ps1
+++ b/Public/Use-PolarisJsonBodyParserMiddleware.ps1
@@ -21,7 +21,7 @@ function Use-PolarisJsonBodyParserMiddleware {
     )
 
     New-PolarisRouteMiddleware -Name JsonBodyParser -Scriptblock {
-        if ( $Null -ne $nequest.BodyString ) {
+        if ( $Null -ne $Request.BodyString ) {
             $Request.Body = $Request.BodyString | ConvertFrom-Json
         }
     } -Force -Polaris $Polaris

--- a/Public/Use-PolarisJsonBodyParserMiddleware.ps1
+++ b/Public/Use-PolarisJsonBodyParserMiddleware.ps1
@@ -1,4 +1,4 @@
-#
+﻿#
 # Copyright (c) Microsoft. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #
@@ -21,7 +21,7 @@ function Use-PolarisJsonBodyParserMiddleware {
     )
 
     New-PolarisRouteMiddleware -Name JsonBodyParser -Scriptblock {
-        if ( $Request.BodyString -ne $Null ) {
+        if ( $Null -ne $nequest.BodyString ) {
             $Request.Body = $Request.BodyString | ConvertFrom-Json
         }
     } -Force -Polaris $Polaris

--- a/Tests/e2e/PolarisServer.Tests.ps1
+++ b/Tests/e2e/PolarisServer.Tests.ps1
@@ -32,6 +32,12 @@ Describe "Test webserver use (E2E)" {
                 $Response.Send('Hello World')
             }
 
+            # Empty Response
+            New-PolarisGetRoute -Path /empty -Scriptblock {
+                $Response.StatusCode = 204
+                $Response.Send()
+            }
+
             # Hello World passing in the Path, Method & Scriptblock
             New-PolarisRoute -Path /hellome -Method GET -Scriptblock {
                 if ($Request.Query['name']) {
@@ -91,6 +97,12 @@ Describe "Test webserver use (E2E)" {
             $Result = Invoke-WebRequest -Uri "http://localhost:$Port/helloworld?test=true&another=one" -UseBasicParsing
             $Result.Content | Should Be 'Hello World'
             $Result.StatusCode | Should Be 200
+        }
+
+        It "test /empty route should return 204 empty" {
+            $Result = Invoke-WebRequest -Uri "http://localhost:$Port/empty" -UseBasicParsing
+            [string]::IsNullOrEmpty($Result.Content) | Should -Be $True
+            $Result.StatusCode | Should -Be 204
         }
 
 

--- a/Tests/e2e/PolarisServer.Tests.ps1
+++ b/Tests/e2e/PolarisServer.Tests.ps1
@@ -35,7 +35,6 @@ Describe "Test webserver use (E2E)" {
             # Empty Response
             New-PolarisGetRoute -Path /empty -Scriptblock {
                 $Response.StatusCode = 204
-                $Response.Send()
             }
 
             # Hello World passing in the Path, Method & Scriptblock

--- a/Tests/e2e/PolarisServer.Tests.ps1
+++ b/Tests/e2e/PolarisServer.Tests.ps1
@@ -32,11 +32,6 @@ Describe "Test webserver use (E2E)" {
                 $Response.Send('Hello World')
             }
 
-            # Empty Response
-            New-PolarisGetRoute -Path /empty -Scriptblock {
-                $Response.StatusCode = 204
-            }
-
             # Hello World passing in the Path, Method & Scriptblock
             New-PolarisRoute -Path /hellome -Method GET -Scriptblock {
                 if ($Request.Query['name']) {
@@ -97,13 +92,6 @@ Describe "Test webserver use (E2E)" {
             $Result.Content | Should Be 'Hello World'
             $Result.StatusCode | Should Be 200
         }
-
-         It "test /empty route should return 204 No Content" {
-            $Result = Invoke-WebRequest -Uri "http://localhost:$Port/empty" -UseBasicParsing
-            [string]::IsNullOrEmpty($Result.Content) | Should -Be $True
-            $Result.StatusCode | Should -Be 204
-        }
-
 
         It "test /header router" {
             $Result = Invoke-WebRequest -Uri "http://localhost:$Port/header" -UseBasicParsing

--- a/Tests/e2e/PolarisServer.Tests.ps1
+++ b/Tests/e2e/PolarisServer.Tests.ps1
@@ -184,6 +184,11 @@ Hello World"
             { Invoke-WebRequest -Uri "http://localhost:$Port/error" -UseBasicParsing } | Should Throw
         }
 
+        It "should have an error response matching the thrown server error" {
+            { Invoke-WebRequest -Uri "http://localhost:$Port/error" -UseBasicParsing }
+            ($Error[0].ErrorDetails.Message -split "`n").Count | Should Be 5
+        }
+
         AfterAll {
             Get-Job | Stop-Job | Remove-Job
         }

--- a/Tests/e2e/Routes.Tests.ps1
+++ b/Tests/e2e/Routes.Tests.ps1
@@ -32,6 +32,10 @@ Describe "Polaris Routing (e2e)" {
                 $Response.Send(($Request.Parameters | ConvertTo-JSON))
             }
 
+            New-PolarisRoute -Path ([Regex]::new("/userRegex/(?<userId>\d+)")) -Method "GET" -Scriptblock {
+                $Response.Send(($Request.Parameters | ConvertTo-JSON))
+            }
+
             New-PolarisRoute -Path "/" -Method "GET" -Scriptblock {
                 $Response.Send("root")
             }
@@ -91,6 +95,11 @@ Describe "Polaris Routing (e2e)" {
 
     It "should allow custom named capture regular expressions" {
         $Result = Invoke-RestMethod -Uri "http://localhost:$Port/user/42" -UseBasicParsing -TimeoutSec 2
+        $Result.userId | Should Be '42'
+    }
+
+    It "should allow custom named capture regular expressions of RegEx type" {
+        $Result = Invoke-RestMethod -Uri "http://localhost:$Port/userRegex/42" -UseBasicParsing -TimeoutSec 2
         $Result.userId | Should Be '42'
     }
 

--- a/Tests/unit/ConvertPathToRegex.Tests.ps1
+++ b/Tests/unit/ConvertPathToRegex.Tests.ps1
@@ -6,60 +6,60 @@
 Import-Module $PSScriptRoot\..\..\Polaris.psd1
 
 InModuleScope Polaris {
-    Describe "[Polaris]::ConvertPathToRegex" {
+    Describe "[PolarisRoute]::ConvertPathToRegex" {
     
         It "should match and extract named parameters anywhere in the route" {
-            $RegEx = [Polaris]::ConvertPathToRegex("/users/:userId/books/:bookId")
+            $RegEx = [PolarisRoute]::ConvertPathToRegex("/users/:userId/books/:bookId")
             "/users/34/books/8989" -cmatch $RegEx | Should Be $true
             $Matches.userId | Should Be 34
             $Matches.bookId | Should Be 8989
         }
 
         It "should interpret . and - literally" {
-            $RegEx = [Polaris]::ConvertPathToRegex("/flights/:from-:to")
+            $RegEx = [PolarisRoute]::ConvertPathToRegex("/flights/:from-:to")
             "/flights/LAX-SFO" -cmatch $RegEx | Should Be $true
             $Matches.from | Should Be "LAX"
             $Matches.to | Should Be "SFO"
 
-            $RegEx = [Polaris]::ConvertPathToRegex("/flights/:from.:to")
+            $RegEx = [PolarisRoute]::ConvertPathToRegex("/flights/:from.:to")
             "/flights/LAX.SFO" -cmatch $RegEx | Should Be $true
             $Matches.from | Should Be "LAX"
             $Matches.to | Should Be "SFO"
         }
 
         It "should allow custom named capture regular expressions" {
-            $RegEx = [Polaris]::ConvertPathToRegex("/user/(?<userId>\d+)")
+            $RegEx = [PolarisRoute]::ConvertPathToRegex("/user/(?<userId>\d+)")
             "/user/42" -cmatch $RegEx | Should Be $true
             $Matches.userId | Should Be 42
         }
 
         It "should provide matches with basic strings" {
-            $RegEx = [Polaris]::ConvertPathToRegex("/")
+            $RegEx = [PolarisRoute]::ConvertPathToRegex("/")
             "/" -cmatch $RegEx | Should Be $true
 
-            $RegEx = [Polaris]::ConvertPathToRegex("/about")
+            $RegEx = [PolarisRoute]::ConvertPathToRegex("/about")
             "/about" -cmatch $RegEx | Should Be $true
 
-            $RegEx = [Polaris]::ConvertPathToRegex("/random.text")
+            $RegEx = [PolarisRoute]::ConvertPathToRegex("/random.text")
             "/random.text" -cmatch $RegEx | Should Be $true
         }
 
         It "should provide matches with string patterns" {
-            $RegEx = [Polaris]::ConvertPathToRegex("/ab?cd")
+            $RegEx = [PolarisRoute]::ConvertPathToRegex("/ab?cd")
             "/acd" -cmatch $RegEx | Should Be $true
             "/abcd" -cmatch $RegEx | Should Be $true
 
-            $RegEx = [Polaris]::ConvertPathToRegex("/ab+cd")
+            $RegEx = [PolarisRoute]::ConvertPathToRegex("/ab+cd")
             "/abcd" -cmatch $RegEx | Should Be $true
             "/abbcd" -cmatch $RegEx | Should Be $true
             "/abbbcd" -cmatch $RegEx | Should Be $true
 
-            $RegEx = [Polaris]::ConvertPathToRegex("/ab*cd")
+            $RegEx = [PolarisRoute]::ConvertPathToRegex("/ab*cd")
             "/abcd" -cmatch $RegEx | Should Be $true
             "/abxcd" -cmatch $RegEx | Should Be $true
             "/abRANDOMcd" -cmatch $RegEx | Should Be $true
 
-            $RegEx = [Polaris]::ConvertPathToRegex("/ab(cd)?e")
+            $RegEx = [PolarisRoute]::ConvertPathToRegex("/ab(cd)?e")
             "/abe" -cmatch $RegEx | Should Be $true
             "/abcde" -cmatch $RegEx | Should Be $true
         }

--- a/Tests/unit/Get-PolarisRoute.Tests.ps1
+++ b/Tests/unit/Get-PolarisRoute.Tests.ps1
@@ -33,7 +33,7 @@ Describe "Get-PolarisRoute" {
     }
 
     It "Should default to get all routes" {
-        $ExpectedCount = (Get-Polaris).ScriptblockRoutes.Values.Values.Count
+        $ExpectedCount = (Get-Polaris).Routes.Count
         $Routes = Get-PolarisRoute
         @( $Routes ).Count | Should Be $ExpectedCount
     }

--- a/Tests/unit/New-PolarisRoute.Tests.ps1
+++ b/Tests/unit/New-PolarisRoute.Tests.ps1
@@ -166,6 +166,19 @@ Describe "New-PolarisRoute" {
         ( Get-PolarisRoute -Path $Path -Method $Method ).Scriptblock | Should Be $NewContent
     }
 
+    It "Should allow regular expressions for the path" {
+        $Params = @{
+            Path = [Regex]::new(".*")
+            Method = "GET"
+            ScriptBlock = {"RegexParams"}
+        }
+
+        # Create route
+        New-PolarisRoute @Params
+
+        (Get-PolarisRoute -Path $Params.Path -Method $Params.Method).ScriptBlock | Should Be $Params.ScriptBlock
+    }
+
     AfterAll {
 
         #  Clean up test routes

--- a/Tests/unit/PolarisRoute.Tests.ps1
+++ b/Tests/unit/PolarisRoute.Tests.ps1
@@ -14,11 +14,7 @@ Describe "Test route creation" {
         $defaultStaticDirectory = "$PSScriptRoot/../resources/static"
 
         function RouteExists ($Path, $Method) {
-            [string]$SanitizedPath = $Path.TrimEnd('/')
-
-            if ( [string]::IsNullOrEmpty($SanitizedPath) ) { $SanitizedPath = "/" }
-
-            return $null -ne (Get-Polaris).ScriptblockRoutes[$SanitizedPath][$Method] 
+            return $null -ne (Get-PolarisRoute -Path $Path -Method $Method)
         }
     }
     Context "Using New-PolarisRoute" {
@@ -128,6 +124,9 @@ Describe "Test route creation" {
     }
 
     Context "Using Get-PolarisRoute and Remove-PolarisRoute" {
+        BeforeEach {
+            New-PolarisRoute -Path "/test" -Method "GET" -Scriptblock $defaultScriptblock
+        }
         It "Will get the object with the routes" {
             ( Get-PolarisRoute -Path "/test" -Method "GET" ).Scriptblock |
                 Should Be $defaultScriptblock.ToString()
@@ -135,9 +134,6 @@ Describe "Test route creation" {
         It "will remove the routes" {
             Remove-PolarisRoute -Path "/test" -Method "GET"
             (Get-PolarisRoute).Count | Should Be 0
-        }
-        BeforeEach {
-            New-PolarisRoute -Path "/test" -Method "GET" -Scriptblock $defaultScriptblock
         }
         AfterEach {
             Clear-Polaris

--- a/Tests/unit/PolarisRoute.Tests.ps1
+++ b/Tests/unit/PolarisRoute.Tests.ps1
@@ -24,10 +24,12 @@ Describe "Test route creation" {
             @{ Path = '/test'; Method = 'POST'; ScriptPath = $null; Scriptblock = $defaultScriptblock }
             @{ Path = '/test'; Method = 'PUT'; ScriptPath = $null; Scriptblock = $defaultScriptblock }
             @{ Path = '/test'; Method = 'DELETE'; ScriptPath = $null; Scriptblock = $defaultScriptblock }
+            @{ Path = [Regex]::new("/testRegex"); Method = 'GET'; ScriptPath = $null; Scriptblock = $defaultScriptblock }
             @{ Path = '/test'; Method = 'GET'; ScriptPath = $defaultScriptPath; Scriptblock = $null }
             @{ Path = '/test'; Method = 'POST'; ScriptPath = $defaultScriptPath; Scriptblock = $null }
             @{ Path = '/test'; Method = 'PUT'; ScriptPath = $defaultScriptPath; Scriptblock = $null }
             @{ Path = '/test'; Method = 'DELETE'; ScriptPath = $defaultScriptPath; Scriptblock = $null }
+            @{ Path = [Regex]::new("/testRegex"); Method = 'GET'; ScriptPath = $defaultScriptPath; Scriptblock = $null }
         ) {
             param ($Path, $Method, $ScriptPath, $Scriptblock)
             if ($ScriptPath) {
@@ -45,6 +47,7 @@ Describe "Test route creation" {
             -TestCases @(
             @{ Path = '/test'; ScriptPath = $defaultScriptPath; Scriptblock = $null }
             @{ Path = '/test'; ScriptPath = $null; Scriptblock = $defaultScriptblock }
+            @{ Path = [Regex]::new("/testRegex"); ScriptPath = $null; Scriptblock = $defaultScriptblock }
         ) {
             param ($Path, $ScriptPath, $Scriptblock)
             if ($ScriptPath -ne $null -and $ScriptPath -ne '') {
@@ -62,6 +65,7 @@ Describe "Test route creation" {
             -TestCases @(
             @{ Path = '/test'; ScriptPath = $defaultScriptPath; Scriptblock = $null }
             @{ Path = '/test'; ScriptPath = $null; Scriptblock = $defaultScriptblock }
+            @{ Path = [Regex]::new("/testRegex"); ScriptPath = $null; Scriptblock = $defaultScriptblock }
         ) {
             param ($Path, $ScriptPath, $Scriptblock)
             if ($ScriptPath) {
@@ -79,6 +83,7 @@ Describe "Test route creation" {
             -TestCases @(
             @{ Path = '/test'; ScriptPath = $defaultScriptPath; Scriptblock = $null }
             @{ Path = '/test'; ScriptPath = $null; Scriptblock = $defaultScriptblock }
+            @{ Path = [Regex]::new("/testRegex"); ScriptPath = $null; Scriptblock = $defaultScriptblock }
         ) {
             param ($Path, $ScriptPath, $Scriptblock)
             if ($ScriptPath) {
@@ -96,6 +101,7 @@ Describe "Test route creation" {
             -TestCases @(
             @{ Path = '/test'; ScriptPath = $defaultScriptPath; Scriptblock = $null }
             @{ Path = '/test'; ScriptPath = $null; Scriptblock = $defaultScriptblock }
+            @{ Path = [Regex]::new("/testRegex"); ScriptPath = $null; Scriptblock = $defaultScriptblock }
         ) {
             param ($Path, $ScriptPath, $Scriptblock)
             if ($ScriptPath) {
@@ -126,13 +132,18 @@ Describe "Test route creation" {
     Context "Using Get-PolarisRoute and Remove-PolarisRoute" {
         BeforeEach {
             New-PolarisRoute -Path "/test" -Method "GET" -Scriptblock $defaultScriptblock
+            New-PolarisRoute -Path ([Regex]::new("/testRegex")) -Method "GET" -Scriptblock $defaultScriptblock
         }
         It "Will get the object with the routes" {
             ( Get-PolarisRoute -Path "/test" -Method "GET" ).Scriptblock |
                 Should Be $defaultScriptblock.ToString()
+
+            ( Get-PolarisRoute -Path "/testRegex" -Method "GET" ).Scriptblock |
+                Should Be $defaultScriptblock.ToString()
         }
         It "will remove the routes" {
             Remove-PolarisRoute -Path "/test" -Method "GET"
+            Remove-PolarisRoute -Path "/testRegex" -Method "GET"
             (Get-PolarisRoute).Count | Should Be 0
         }
         AfterEach {

--- a/docs/about_Routing.md
+++ b/docs/about_Routing.md
@@ -1,0 +1,203 @@
+---
+layout: default
+title: About Routing
+type: about
+---
+
+# Routing
+
+## about_Routing
+
+#  SHORT DESCRIPTION
+
+
+**Routing** refers to determining how an application responds to a client request to a particular endpoint, which is a URI (or path) and a specific HTTP request method (GET, POST, and so on).
+
+Polaris routes are declared using the `New-PolarisRoute` cmdlet as follows:
+
+```pwsh
+New-PolarisRoute -Path "/" -Method GET -Scriptblock { $Response.Send("Hello World!") }
+```
+
+This means that when a request is made to the root (`/`) of your site using the HTTP method GET Polaris will respond with `Hello World`.
+
+You can also use a slightly shortened alternative syntax as follows:
+
+```pwsh
+New-PolarisGetRoute -Path "/" -Scriptblock { $Response.Send("Hello World!") }
+```
+
+If you wanted to respond to a POST instead of a GET you would simply change the method:
+
+```pwsh
+New-PolarisRoute -Path "/" -Method POST -Scriptblock { $Response.Send("Hello World!") }
+```
+
+You can also use parameters in the path as follows:
+
+```pwsh
+New-PolarisRoute -Path "/hello/:firstname/:lastname" -Method GET -Scriptblock { $Response.Send("Hello $($Request.Parameters.firstname) $($Request.Parameters.lastname)!") }
+```
+
+An HTTP request using the GET method to the following uri `/hello/Bobby/Dylan` would result in a response of `Hello Bobby Dylan!`.
+
+# LONG DESCRIPTION
+
+
+
+## Examples of basic simple route matching
+
+This route path will match requests to the root route, /.
+```ps
+New-PolarisRoute -Path "/" -ScriptBlock {
+   $Response.Send('root')
+}
+```
+
+This route path will match requests to /about.
+```ps
+New-PolarisRoute -Path "/about" -ScriptBlock {
+   $Response.Send('about')
+}
+```
+
+This route path will match requests to /random.text.
+```ps
+New-PolarisRoute -Path "/random.text" -ScriptBlock {
+   $Response.Send('random.text')
+}
+```
+
+## Here are some examples of route paths based on string patterns.
+
+This route path will match acd and abcd.
+```ps
+New-PolarisRoute -Path "/ab?cd" -ScriptBlock {
+   $Response.Send('ab?cd')
+}
+```
+
+This route path will match abcd, abbcd, abbbcd, and so on.
+```ps
+New-PolarisRoute -Path "/ab+cd" -ScriptBlock {
+   $Response.Send('/ab+cd')
+}
+```
+
+This route path will match abcd, abxcd, abRANDOMcd, ab123cd, and so on.
+```ps
+New-PolarisRoute -Path "/ab*cd" -ScriptBlock {
+   $Response.Send('/ab*cd')
+}
+```
+
+This route path will match /abe and /abcde.
+```ps
+New-PolarisRoute -Path "/ab(cd)?e" -ScriptBlock {
+   $Response.Send('/ab(cd)?e')
+}
+```
+
+## Examples of route paths based on regular expressions:
+
+This route path will match anything with an “a” in it.
+```ps
+New-PolarisRoute -Path [RegEx]::New("a") -ScriptBlock {
+   $Response.Send('a')
+}
+```
+
+This route path will match butterfly and dragonfly, but not butterflyman, dragonflyman, and so on.
+```ps
+New-PolarisRoute -Path [RegEx]::New(".*fly$") -ScriptBlock {
+   $Response.Send('.*fly$')
+}
+```
+
+## Route parameters
+Route parameters are named URL segments that are used to capture the values specified at their position in the URL. The captured values are populated in the req.params object, with the name of the route parameter specified in the path as their respective keys.
+
+```
+Route path: /users/:userId/books/:bookId
+Request URL: http://localhost:3000/users/34/books/8989
+$Request.parameters: { "userId": "34", "bookId": "8989" }
+```
+
+To define routes with route parameters, simply specify the route parameters in the path of the route as shown below.
+
+```ps
+New-PolarisRoute -Path "/users/:userId/books/:bookId" -ScriptBlock {
+   $Response.Send($Request.Parameters)
+}
+```
+
+The name of route parameters must be made up of “word characters” ([A-Za-z0-9_]).
+
+Since the hyphen (-) and the dot (.) are interpreted literally, they can be used along with route parameters for useful purposes.
+
+```
+Route path: /flights/:from-:to
+Request URL: http://localhost:3000/flights/LAX-SFO
+$Request.Parameters: { "from": "LAX", "to": "SFO" }
+```
+
+```
+Route path: /plantae/:genus.:species
+Request URL: http://localhost:3000/plantae/Prunus.persica
+$Request.Parameters: { "genus": "Prunus", "species": "persica" }
+```
+
+## Advanced Cases for Routing
+
+In the case where the above does not suit your needs you also have the option to declare routes using .Net Regular Expressions. The value of $Matches from the regular expression will be available in $Request.Parameters so any named capture groups will flow directly through.
+
+```
+Route path: [RegEx]::("^/plantae/(?<genus>.+)\.(?<species>.+)$")
+Request URL: http://localhost:3000/plantae/Prunus.persica
+$Request.Parameters: { "genus": "Prunus", "species": "persica" }
+```
+
+## How things work under the hood
+
+New-PolarisRoute creates a new instance of the class [PolarisRoute] and sets the value of Path, Method and Scriptblock using the values you pass as arguments. The PolarisRoute class has logic that will determine whether the Path passed was a string of a Regular Expression.
+
+If it is a string there is a simple conversion run that converts the path string into a regular expression. For example `/home` will get converted into `^/home$` and `/plantae/:genus.:species` will get converted into `^/plantae/(?<genus>.+)\.(?<species>.+)$`.
+
+Each PolarisRoute is stored in an array and when an incoming request is received Polaris will iterate through the array of routes to determine if the method and URI of the request match any of the PolarisRoutes. If it finds a match it will set $Request.Parameters to the value of $Matches cast to a [pscustomobject] and will execute the corresponding ScriptBlock.
+
+# TROUBLESHOOTING NOTE
+
+If you're not sure why a route you've made isn't executing. It may be helpful to review the regular expression yourself and play with the value of your path until you find one that works for you.
+
+You can do that by manually inspecting the array of routes stored on Polaris.
+
+```pwsh
+> $Polaris = Get-Polaris
+> $Polaris.Routes
+```
+
+```
+Path         Regex                Method Scriptblock
+----         -----                ------ -----------
+/hello/:name ^/hello/(?<name>.+)$ GET     $Response.Send("Hello $($Parameters.Name)")
+```
+
+You can modify the value of Path directly and the value of Regex will update to match. You can then simply test it via:
+
+```pwsh
+> "/hello/bobby" -match $Polaris.Routes[0].Regex
+
+$true
+```
+
+You can also inspect what the parameters will look like via:
+
+```pwsh
+> "/hello/bobby" -match $Polaris.Routes[0].Regex
+$true
+> [pscustomobject]$Matches
+
+name  0
+----  -
+bobby /hello/bobby
+```

--- a/docs/about_Routing.md
+++ b/docs/about_Routing.md
@@ -10,7 +10,6 @@ type: about
 
 #  SHORT DESCRIPTION
 
-
 **Routing** refers to determining how an application responds to a client request to a particular endpoint, which is a URI (or path) and a specific HTTP request method (GET, POST, and so on).
 
 Polaris routes are declared using the `New-PolarisRoute` cmdlet as follows:
@@ -43,8 +42,6 @@ An HTTP request using the GET method to the following uri `/hello/Bobby/Dylan` w
 
 # LONG DESCRIPTION
 
-
-
 ## Examples of basic simple route matching
 
 This route path will match requests to the root route, /.
@@ -61,10 +58,10 @@ New-PolarisRoute -Path "/about" -ScriptBlock {
 }
 ```
 
-This route path will match requests to /random.text.
+This route path will match requests to /random.txt.
 ```ps
-New-PolarisRoute -Path "/random.text" -ScriptBlock {
-   $Response.Send('random.text')
+New-PolarisRoute -Path "/random.txt" -ScriptBlock {
+   $Response.Send('random.txt')
 }
 ```
 

--- a/lib/Polaris.Class.ps1
+++ b/lib/Polaris.Class.ps1
@@ -87,6 +87,7 @@ class Polaris {
                         
                     }
                     catch {
+                        $ErrorsBody = ''
                         $ErrorsBody += $_.Exception.ToString()
                         $ErrorsBody += $_.InvocationInfo.PositionMessage + "`n`n"
                         $Response.Send($ErrorsBody)

--- a/lib/Polaris.Class.ps1
+++ b/lib/Polaris.Class.ps1
@@ -312,12 +312,23 @@ class Polaris {
         [string]$ContentType, 
         [System.Net.WebHeaderCollection]$Headers
     ) {
-        $RawResponse.StatusCode = $StatusCode;
-        $RawResponse.Headers = $Headers;
-        $RawResponse.ContentType = $ContentType;
-        $RawResponse.ContentLength64 = $ByteResponse.Length;
-        $RawResponse.OutputStream.Write($ByteResponse, 0, $ByteResponse.Length);
-        $RawResponse.OutputStream.Close();
+        if (-not ($ByteResponse.Count -eq 1 -and $ByteResponse[0] -eq 0)) {
+            Write-Debug "`$ByteResponse: $ByteResponse"
+            Write-Debug "`$ByteResponse.Length: $($ByteResponse.Length)"
+            $RawResponse.StatusCode = $StatusCode;
+            $RawResponse.Headers = $Headers;
+            $RawResponse.ContentType = $ContentType;
+            $RawResponse.ContentLength64 = $ByteResponse.Length;
+            $RawResponse.OutputStream.Write($ByteResponse, 0, $ByteResponse.Length);
+            $RawResponse.OutputStream.Close();
+        }
+        else {
+            Write-Debug "Sending empty response"
+            $RawResponse.StatusCode = $StatusCode;
+            $RawResponse.Headers = $Headers
+            $RawResponse.SendChunked = $False
+            $RawResponse.Close()
+        }
     }
     
     static [void] Send (

--- a/lib/Polaris.Class.ps1
+++ b/lib/Polaris.Class.ps1
@@ -309,23 +309,12 @@ class Polaris {
         [string]$ContentType, 
         [System.Net.WebHeaderCollection]$Headers
     ) {
-        if (-not ($ByteResponse.Count -eq 1 -and $ByteResponse[0] -eq 0)) {
-            Write-Debug "`$ByteResponse: $ByteResponse"
-            Write-Debug "`$ByteResponse.Length: $($ByteResponse.Length)"
-            $RawResponse.StatusCode = $StatusCode;
-            $RawResponse.Headers = $Headers;
-            $RawResponse.ContentType = $ContentType;
-            $RawResponse.ContentLength64 = $ByteResponse.Length;
-            $RawResponse.OutputStream.Write($ByteResponse, 0, $ByteResponse.Length);
-            $RawResponse.OutputStream.Close();
-        }
-        else {
-            Write-Debug "Sending empty response"
-            $RawResponse.StatusCode = $StatusCode;
-            $RawResponse.Headers = $Headers
-            $RawResponse.SendChunked = $False
-            $RawResponse.Close()
-        }
+        $RawResponse.StatusCode = $StatusCode;
+        $RawResponse.Headers = $Headers;
+        $RawResponse.ContentType = $ContentType;
+        $RawResponse.ContentLength64 = $ByteResponse.Length;
+        $RawResponse.OutputStream.Write($ByteResponse, 0, $ByteResponse.Length);
+        $RawResponse.OutputStream.Close();
     }
     
     static [void] Send (

--- a/lib/Polaris.Class.ps1
+++ b/lib/Polaris.Class.ps1
@@ -96,10 +96,6 @@ class Polaris {
                             $Request,
                             $Response
                         )
-                        <<<<<<< HEAD
-                        =======
-
-                        >>>>>>> upstream/master
                     }
                     catch {
                         $ErrorsBody = ''

--- a/lib/Polaris.Class.ps1
+++ b/lib/Polaris.Class.ps1
@@ -6,8 +6,8 @@
 class Polaris {
 
     [int]$Port
-    [System.Collections.Generic.List[PolarisMiddleWare]]$RouteMiddleWare = [System.Collections.Generic.List[PolarisMiddleWare]]::new()
-    [System.Collections.Generic.Dictionary[string, [System.Collections.Generic.Dictionary[string, scriptblock]]]]$ScriptblockRoutes = [System.Collections.Generic.Dictionary[string, [System.Collections.Generic.Dictionary[string, scriptblock]]]]::new()
+    [System.Collections.Generic.List[PolarisMiddleware]]$RouteMiddleWare = [System.Collections.Generic.List[PolarisMiddleWare]]::new()
+    [PolarisRoute[]]$Routes = @()
     hidden [Action[string]]$Logger
     hidden [System.Net.HttpListener]$Listener
     hidden [bool]$StopServer = $False
@@ -41,11 +41,11 @@ class Polaris {
             [PolarisResponse]$Response = [PolarisResponse]::new($Context.Response)
 
 
-            [string]$Route = $RawRequest.Url.AbsolutePath
+            [string]$RequestedRoute = $RawRequest.Url.AbsolutePath
             
             [System.Management.Automation.InformationRecord[]]$InformationVariable = @()
 
-            if ([string]::IsNullOrEmpty($Route)) { $Route = "/" }
+            if ([string]::IsNullOrEmpty($RequestedRoute)) { $RequestedRoute = "/" }
 
             try {
 
@@ -59,32 +59,42 @@ class Polaris {
                     )
                 }
 
-                $Polaris.Log("Parsed Route: $Route")
+                $Polaris.Log("Parsed Route: $RequestedRoute")
                 $Polaris.Log("Request Method: $($RawRequest.HttpMethod)")
-                $Routes = $Polaris.ScriptblockRoutes
+                $Routes = $Polaris.Routes
 
                 #
                 # Searching for the first route that matches by the most specific route paths first.
                 #
-                $MatchingRoute = $Routes.keys | Sort-Object -Property Length -Descending | Where-Object { $Route -match [Polaris]::ConvertPathToRegex($_) } | Select-Object -First 1
-                $Request.Parameters = ([PSCustomObject]$Matches)
-                Write-Debug "Parameters: $Parameters"
-                $MatchingMethod = $false
-
-                if ($MatchingRoute) {
-                    $MatchingMethod = $Routes[$MatchingRoute].keys -contains $Request.Method
+                $MatchingRoute = $Null
+                $HasMatchingMethod = $false
+                foreach ($Route in $Routes) {
+                    Write-Debug "Testing Route: `n`n $( $Route | ConvertTo-Json )"
+                    $IsMatchingMethod = $Route.Method -eq $Request.Method
+                    Write-Debug "`$IsMatchingMethod = `$Route.Method($($Route.Method)) -eq `$Request.Method($($Request.Method))"
+                    $IsMatchingRoute = $RequestedRoute -match $Route.Regex
+                    Write-Debug "`$IsMatchingRoute = `$RequestedRoute($($RequestedRoute)) -match `$Route.Regex($($Route.Regex))"
+                    if ( $IsMatchingMethod -and $IsMatchingRoute ) {
+                        $MatchingRoute = $Route
+                        $HasMatchingMethod = $true
+                        break
+                    }
+                    elseif ( $IsMatchingRoute ) {
+                        $MatchingRoute = $Route
+                    }
                 }
 
-                if ($MatchingRoute -and $MatchingMethod) {
-                    try {
+                $Request.Parameters = ([PSCustomObject]$Matches)
+                Write-Debug "Parameters: $($Request.Parameters)"
 
+                if ($MatchingRoute -and $HasMatchingMethod) {
+                    try {
                         $InformationVariable += $Polaris.InvokeRoute(
-                            $Routes[$MatchingRoute][$Request.Method],
+                            $MatchingRoute.ScriptBlock,
                             $Parameters,
                             $Request,
                             $Response
                         )
-                        
                     }
                     catch {
                         $ErrorsBody = ''
@@ -164,20 +174,16 @@ class Polaris {
 
 
     [void] AddRoute (
-        [string]$Path,
+        $Path,
         [string]$Method,
         [scriptblock]$Scriptblock
     ) {
         if ($null -eq $Scriptblock) {
-            throw [ArgumentNullException]::new("scriptBlock")
+            throw [ArgumentNullException]::new("ScriptBlock")
         }
 
-        [string]$SanitizedPath = [Polaris]::SanitizePath($Path)
-
-        if (-not $this.ScriptblockRoutes.ContainsKey($SanitizedPath)) {
-            $this.ScriptblockRoutes[$SanitizedPath] = [System.Collections.Generic.Dictionary[string, string]]::new()
-        }
-        $this.ScriptblockRoutes[$SanitizedPath][$Method] = $Scriptblock
+        $this.Routes += [PolarisRoute]::new($Method, $Path, $Scriptblock)
+        $this.Routes = $this.Routes | Sort-Object -Property {$_.Path.Length} -Descending
     }
 
     RemoveRoute (
@@ -185,54 +191,13 @@ class Polaris {
         [string]$Method
     ) {
         if ($null -eq $Path) {
-            throw [ArgumentNullException]::new("path")
+            throw [ArgumentNullException]::new("Path")
         }
         if ($null -eq $Method) {
-            throw [ArgumentNullException]::new("method")
+            throw [ArgumentNullException]::new("Method")
         }
 
-        [string]$SanitizedPath = [Polaris]::SanitizePath($Path)
-
-        $this.ScriptblockRoutes[$SanitizedPath].Remove($Method)
-        if ($this.ScriptblockRoutes[$SanitizedPath].Count -eq 0) {
-            $this.ScriptblockRoutes.Remove($SanitizedPath)
-        }
-    }
-
-    static [string] SanitizePath([string]$Path) {
-        $SanitizedPath = $Path.TrimEnd('/')
-
-        if ([string]::IsNullOrEmpty($SanitizedPath)) { $SanitizedPath = "/" }
-
-        return $SanitizedPath
-    }
-
-    static [RegEx] ConvertPathToRegex([string]$Path) {
-        Write-Debug "Path: $path"
-        # Replacing all periods with an escaped period to prevent regex wildcard
-        $path = $path -replace '\.', '\.'
-        # Replacing all - with \- to escape the dash
-        $path = $path -replace '-', '\-'
-        # Replacing the wildcard character * with a regex aggressive match .*
-        $path = $path -replace '\*', '.*'
-        # Creating a strictly matching regular expression that must match beginning (^) to end ($)
-        $path = "^$path$"
-        # Creating a route based parameter
-        #   Match any and all word based characters after the : for the name of the parameter
-        #   Use the name in a named capture group that will show up in the $matches variable
-        #   References:
-        #       - https://docs.microsoft.com/en-us/dotnet/standard/base-types/grouping-constructs-in-regular-expressions#named_matched_subexpression
-        #       - https://technet.microsoft.com/en-us/library/2007.11.powershell.aspx
-        #       - https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-6#matches
-        $path = $path -replace ":(\w+)(\?{0,1})", '(?<$1>.+)$2'
-
-        Write-Debug "Parsed Regex: $path"
-        return [RegEx]::New($path)
-    }
-
-    static [RegEx] ConvertPathToRegex([RegEx]$Path) {
-        Write-Debug "Path is a RegEx"
-        return $Path
+        $this.Routes = $this.Routes | Where-Object { -not ($_.Path -eq $Path -and $_.Method -eq $Method) }
     }
 
     AddMiddleware (

--- a/lib/Polaris.Class.ps1
+++ b/lib/Polaris.Class.ps1
@@ -75,13 +75,12 @@ class Polaris {
                     Write-Debug "`$IsMatchingMethod = `$Route.Method($($Route.Method)) -eq `$Request.Method($($Request.Method))"
                     $IsMatchingRoute = $RequestedRoute -match $Route.Regex
                     Write-Debug "`$IsMatchingRoute = `$RequestedRoute($($RequestedRoute)) -match `$Route.Regex($($Route.Regex))"
-                    if ( $IsMatchingMethod -and $IsMatchingRoute ) {
+                    if ( $IsMatchingRoute ) {
                         $MatchingRoute = $Route
-                        $HasMatchingMethod = $true
-                        break
-                    }
-                    elseif ( $IsMatchingRoute ) {
-                        $MatchingRoute = $Route
+                        if ( $IsMatchingMethod ) {
+                            $HasMatchingMethod = $true
+                            break
+                        }
                     }
                 }
 

--- a/lib/PolarisRoute.Class.ps1
+++ b/lib/PolarisRoute.Class.ps1
@@ -1,0 +1,110 @@
+#
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+
+class PolarisRoute {
+    
+    [string]
+    $Method
+
+    [scriptblock]
+    $Scriptblock
+
+    [string]
+    hidden $_Path
+    
+    [regex]
+    hidden $_Regex
+
+    PolarisRoute([string]$Method, $Path, [scriptblock]$Scriptblock) {
+        $this.Scriptblock = $Scriptblock
+        $this.Method = $Method
+        $this._Path = [PolarisRoute]::SanitizePath($Path)
+        $this._Regex = [PolarisRoute]::ConvertPathToRegex($Path)
+
+        $Path_Get = {
+            # Getter
+            return $this._Path
+        }
+
+        $Path_Set = {
+            # Setter
+            param($value)
+            $this._Path = [PolarisRoute]::SanitizePath($value)
+            $this._Regex = [PolarisRoute]::ConvertPathToRegex($value)
+        }
+
+        $PathProperty = @{
+            Name        = "Path"
+            Value       = $Path_Get
+            SecondValue = $Path_Set
+            MemberType  = "ScriptProperty"
+        }
+
+        $this | Add-Member @PathProperty
+
+        $Regex_Get = {
+            # Getter
+            return $this._Regex
+        }
+
+        $Regex_Set = {
+            # Setter
+            param($value)
+            Write-Warning "Regex is a read-only property. Update the Path property instead."
+        }
+
+        $RegexProperty = @{
+            Name        = "Regex"
+            Value       = $Regex_Get
+            SecondValue = $Regex_Set
+            MemberType  = "ScriptProperty"
+        }
+
+        $this | Add-Member @RegexProperty
+
+
+    }
+
+    hidden static [RegEx] ConvertPathToRegex([string]$Path) {
+        Write-Debug "Path: $path"
+        # Replacing all periods with an escaped period to prevent regex wildcard
+        $path = $path -replace '\.', '\.'
+        # Replacing all - with \- to escape the dash
+        $path = $path -replace '-', '\-'
+        # Replacing the wildcard character * with a regex aggressive match .*
+        $path = $path -replace '\*', '.*'
+        # Creating a strictly matching regular expression that must match beginning (^) to end ($)
+        $path = "^$path$"
+        # Creating a route based parameter
+        #   Match any and all word based characters after the : for the name of the parameter
+        #   Use the name in a named capture group that will show up in the $matches variable
+        #   References:
+        #       - https://docs.microsoft.com/en-us/dotnet/standard/base-types/grouping-constructs-in-regular-expressions#named_matched_subexpression
+        #       - https://technet.microsoft.com/en-us/library/2007.11.powershell.aspx
+        #       - https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-6#matches
+        $path = $path -replace ":(\w+)(\?{0,1})", '(?<$1>.+)$2'
+
+        Write-Debug "Parsed Regex: $path"
+        return [RegEx]::New($path)
+    }
+
+    hidden static [RegEx] ConvertPathToRegex([RegEx]$Path) {
+        Write-Debug "Path is a RegEx"
+        return $Path
+    }
+
+    hidden static [string] SanitizePath([string]$Path) {
+        $SanitizedPath = $Path.TrimEnd('/')
+
+        if ([string]::IsNullOrEmpty($SanitizedPath)) { $SanitizedPath = "/" }
+
+        return $SanitizedPath
+    }
+
+    hidden static [string] SanitizePath([regex]$Path) {
+        return $Path
+    }
+}

--- a/lib/PolarisRoute.Class.ps1
+++ b/lib/PolarisRoute.Class.ps1
@@ -3,7 +3,6 @@
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #
 
-
 class PolarisRoute {
     
     [string]
@@ -15,7 +14,7 @@ class PolarisRoute {
     [string]
     hidden $_Path
     
-    [regex]
+    [RegEx]
     hidden $_Regex
 
     PolarisRoute([string]$Method, $Path, [scriptblock]$Scriptblock) {
@@ -70,11 +69,11 @@ class PolarisRoute {
 
     hidden static [RegEx] ConvertPathToRegex([string]$Path) {
         Write-Debug "Path: $path"
-        # Replacing all periods with an escaped period to prevent regex wildcard
+        # Replacing all periods with an escaped period to prevent RegEx wildcard
         $path = $path -replace '\.', '\.'
         # Replacing all - with \- to escape the dash
         $path = $path -replace '-', '\-'
-        # Replacing the wildcard character * with a regex aggressive match .*
+        # Replacing the wildcard character * with a RegEx aggressive match .*
         $path = $path -replace '\*', '.*'
         # Creating a strictly matching regular expression that must match beginning (^) to end ($)
         $path = "^$path$"
@@ -104,7 +103,7 @@ class PolarisRoute {
         return $SanitizedPath
     }
 
-    hidden static [string] SanitizePath([regex]$Path) {
+    hidden static [string] SanitizePath([RegEx]$Path) {
         return $Path
     }
 }


### PR DESCRIPTION
## WIP Checklist

- [x] Fully implement RFC 001
- [x] Add about_Routing.md

## Pull Request Description

Finally got around to finishing the full implementation of what was discussed in RFC 001 (#120). You can now pass in an actual [RegEx] type as your path if you would like. Otherwise it will still support regular strings and string patterns.

I'm going to write up the docs for this over the next couple of days but wanted to open this up as WIP to get some feedback on the changes I made to the Polaris class public property **ScriptBlockRoutes** which are:

1. I renamed it from ScriptBlockRoutes to **Routes**
2. I changed it from a key value of key values to be a new class called [PolarisRoute]

The [PolarisRoute] class has several niceties that I felt were missing in the old system and I believe I have simplified things quite a bit. Instead of having to loop through keys and convert path strings to regular expressions at run time we convert the path to regular expression in the setter function of the path property on the [PolarisRoute] which 1) makes for easier debugging as you can see what the URL is getting matched against for your given path 2) saves some processing time as the paths are only converted to regular expressions once.

Example case given the following routes:

```pwsh
New-PolarisRoute -Path "/users/:userId/books/:bookId" -Method "GET" -Scriptblock {
    $Response.Send(($Request.Parameters | ConvertTo-JSON))
}

New-PolarisRoute -Path "/flights/:from-:to" -Method "GET" -Scriptblock {
    $Response.Send(($Request.Parameters | ConvertTo-JSON))
}

New-PolarisRoute -Path "/flights/:from.:to" -Method "GET" -Scriptblock {
    $Response.Send(($Request.Parameters | ConvertTo-JSON))
}

New-PolarisRoute -Path "/user/(?<userId>\d+)" -Method "GET" -Scriptblock {
    $Response.Send(($Request.Parameters | ConvertTo-JSON))
}

New-PolarisRoute -Path ([Regex]::new("/userRegex/(?<userId>\d+)")) -Method "GET" -Scriptblock {
    $Response.Send(($Request.Parameters | ConvertTo-JSON))
}

New-PolarisRoute -Path "/" -Method "GET" -Scriptblock {
    $Response.Send("root")
}

New-PolarisRoute -Path "/about" -Method "GET" -Scriptblock {
    $Response.Send("about")
}

New-PolarisRoute -Path "/random.text" -Method "GET" -Scriptblock {
    $Response.Send("random.text")
}

New-PolarisRoute -Path "/12?34" -Method "GET" -Scriptblock {
    $Response.Send("12?34")
}

New-PolarisRoute -Path "/ab+cd" -Method "GET" -Scriptblock {
    $Response.Send("ab+cd")
}

New-PolarisRoute -Path "/ef*gh" -Method "GET" -Scriptblock {
    $Response.Send("ef*gh")
}

New-PolarisRoute -Path "/ij(kl)?m" -Method "GET" -Scriptblock {
    $Response.Send("ij(kl)?m")
}
```

You may now view them easily like this:

```shell
PS C:\my\Polaris> $Polaris = Get-Polaris
PS C:\my\Polaris> $Polaris.Routes

Path                         Regex                                      Method Scriptblock
----                         -----                                      ------ -----------
/users/:userId/books/:bookId ^/users/(?<userId>.+)/books/(?<bookId>.+)$ GET    ...
/userRegex/(?<userId>\d+)    /userRegex/(?<userId>\d+)                  GET    ...
/user/(?<userId>\d+)         ^/user/(?<userId>\d+)$                     GET    ...
/flights/:from-:to           ^/flights/(?<from>.+)\-(?<to>.+)$          GET    ...
/flights/:from.:to           ^/flights/(?<from>.+)\.(?<to>.+)$          GET    ...
/random.text                 ^/random\.text$                            GET    ...
/ij(kl)?m                    ^/ij(kl)?m$                                GET    ...
/about                       ^/about$                                   GET    ...
/12?34                       ^/12?34$                                   GET    ...
/ef*gh                       ^/ef.*gh$                                  GET    ...
/ab+cd                       ^/ab+cd$                                   GET    ...
/                            ^/$                                        GET    ...
```

Fixes #134
---

# Pull Request Creation Checklist

-   [x] Useful title (i.e. **Fix #XXX: Description** / **Feature #XXX: Description** / **RFC #XXX: Description**)
-   [x] Description of the changes you are making
-   [x] Added a link to the related Github issue in the description (i.e. type `Fixes #XXX` in the desciption of the PR)
-   [x] If you are still working on the code and would like some early feedback via the Pull Request process just add [WIP] to the beginning of your Pull Request title
-   [x] Checked the [Polaris GitHub workflow guidance](/GITHUB_GUIDANCE.md) to make sure my code has the latest changes made to the master branch
-   [x] Throw small party 🎉 
