### PR TITLE
Added Hostname Support for Specific Bindings

### DIFF
--- a/Public/Start-Polaris.ps1
+++ b/Public/Start-Polaris.ps1
@@ -51,6 +51,9 @@ function Start-Polaris {
             })]            
         [switch]
         $Https = $False,
+        
+        [String]
+        $HostName = 'localhost',
 
         [ValidateSet('Anonymous', 'Basic', 'Digest', 'IntegratedWindowsAuthentication', 'Negotiate', 'NTLM')]
         [ValidateScript( {
@@ -76,7 +79,7 @@ function Start-Polaris {
         Use-PolarisJsonBodyParserMiddleware -Polaris $Polaris
     }
 
-    $Polaris.Start( $Port, $Https.IsPresent, $Auth)
+    $Polaris.Start( $Port, $Https.IsPresent, $Auth, $HostName)
 
     return $Polaris
 }

--- a/Public/Start-Polaris.ps1
+++ b/Public/Start-Polaris.ps1
@@ -16,6 +16,9 @@
     When present, JSONBodyParser middleware will be created, if needed.
 .PARAMETER Https
     Determines if you want to use https as the prefix.
+.PARAMETER HostName
+    Determines the hostname used in the URL prefix. 
+    Defaults to localhost.
 .PARAMETER Auth
     Polaris will use various authentication methods to authenticate requests.
 .PARAMETER Polaris

--- a/Tests/e2e/PolarisHostName.Tests.ps1
+++ b/Tests/e2e/PolarisHostName.Tests.ps1
@@ -1,0 +1,110 @@
+#
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+Describe "Hostname Parameter" {
+
+    BeforeAll {
+        
+        #Start the server with a function to not repeat code
+        function New-PolarisHostTest {
+            Param
+            (
+                [Parameter(Mandatory = $true)]
+                $HostName
+            )
+            Process {
+                Start-Job -ArgumentList @($HostName) -Scriptblock {
+                    # Import Polaris
+                    Import-Module -Name $using:PSScriptRoot\..\..\Polaris.psd1
+
+                    $HostName = $args[0]
+                    $DebugPreference = "Continue"
+
+                    New-PolarisRoute -Path /helloworld -Method GET -Scriptblock {
+                        $Response.Send('Hello World')
+                    }
+
+                    # Start the app
+                    $Polaris = Start-Polaris -Port 8080 -HostName $HostName
+
+                    # Keeping the job running while the tests are running
+                    while ($Polaris.Listener.IsListening) {
+                        Wait-Event callbackeventbridge.callbackcomplete
+                    }
+                }
+
+                # Giving server job time to start up
+                Start-Sleep -seconds 8
+            }
+        }
+
+        function Stop-PolarisHostTest {
+            Get-Job | Stop-Job -PassThru | Remove-Job
+        }
+    }
+    
+    Context "Using localhost as hostname" {
+        New-PolarisHostTest -hostname "localhost"
+
+        It "test /helloworld route" {
+            $Result = Invoke-WebRequest -Uri "http://localhost:8080/helloworld" -UseBasicParsing -TimeoutSec 2
+            $Result.Content | Should Be 'Hello World'
+            $Result.StatusCode | Should Be 200
+        }
+
+        It "test GET to /IDontExist route" {
+            try {
+                Invoke-RestMethod -Uri "http://localhost:8080/IDontExist" -Method POST
+            }
+            catch {
+                $_.Exception.Response.StatusCode.value__ | Should Be 404
+            }
+        }
+
+        Stop-PolarisHostTest
+    }
+
+    Context "Using 127.0.0.1 as hostname" {
+        New-PolarisHostTest -hostname "127.0.0.1"
+
+        It "test /helloworld route" {
+            $Result = Invoke-WebRequest -Uri "http://127.0.0.1:8080/helloworld" -UseBasicParsing -TimeoutSec 2
+            $Result.Content | Should Be 'Hello World'
+            $Result.StatusCode | Should Be 200
+        }
+
+        It "test GET to /IDontExist route" {
+            try {
+                Invoke-RestMethod -Uri "http://127.0.0.1:8080/IDontExist" -Method POST
+            }
+            catch {
+                $_.Exception.Response.StatusCode.value__ | Should Be 404
+            }
+        }
+
+        Stop-PolarisHostTest
+    }
+
+    Context "Using + as hostname" {
+        New-PolarisHostTest -hostname "+"
+
+        It "test /helloworld route" {
+            $Result = Invoke-WebRequest -Uri "http://localhost:8080/helloworld" -UseBasicParsing -TimeoutSec 2
+            $Result.Content | Should Be 'Hello World'
+            $Result.StatusCode | Should Be 200
+        }
+
+        It "test GET to /IDontExist route" {
+            try {
+                Invoke-RestMethod -Uri "http://localhost:8080/IDontExist" -Method POST
+            }
+            catch {
+                $_.Exception.Response.StatusCode.value__ | Should Be 404
+            }
+        }
+
+        Stop-PolarisHostTest
+    }
+}

--- a/lib/Polaris.Class.ps1
+++ b/lib/Polaris.Class.ps1
@@ -287,12 +287,12 @@ class Polaris {
         $this.Listener = [System.Net.HttpListener]::new()
 
         if ($Https) {
-            $this.Log("Using HTTPS:")
             $ListenerPrefix = "https"
         }
         else {
             $ListenerPrefix = "http"
         }
+        
         $this.UriPrefix = $ListenerPrefix + '://' + $HostName + ':' + $this.Port + '/'
 
         $this.Listener.Prefixes.Add($this.UriPrefix)

--- a/lib/Polaris.Class.ps1
+++ b/lib/Polaris.Class.ps1
@@ -292,12 +292,12 @@ class Polaris {
         else {
             $ListenerPrefix = "http"
         }
-        
+
         $this.UriPrefix = $ListenerPrefix + '://' + $HostName + ':' + $this.Port + '/'
 
         $this.Listener.Prefixes.Add($this.UriPrefix)
 
-        $this.Log("URI Prefix set to: $this.UriPrefix")
+        $this.Log("URI Prefix set to: $($this.UriPrefix)")
 
         $this.Listener.AuthenticationSchemes = $Auth
 


### PR DESCRIPTION
# Pull Request Creation Checklist

-   [x] Useful title (i.e. **Fix #XXX: Description** / **Feature #XXX: Description** / **RFC #XXX: Description**)
-   [x] Description of the changes you are making
-   [x] Added a link to the related Github issue in the description (i.e. type `Fixes #XXX` in the desciption of the PR)
-   [x] If you are still working on the code and would like some early feedback via the Pull Request process just add [WIP] to the beginning of your Pull Request title
-   [x] Checked the [Polaris GitHub workflow guidance](/GITHUB_GUIDANCE.md) to make sure my code has the latest changes made to the master branch
-   [x] Throw small party 🎉 

I added a hostname parameter as requested from issue #156. This allows the binding to be for a more specific hostname. Before the behavior on Linux/OSX or running on Windows as admin, we used the wildcard `+` as the binding. If it was ran as non-admin on Windows we used localhost as the binding. Now, we are defaulting to localhost, and allowing users to set the hostname as needed. There are also security concerns with defaulting to the wildcard.  This fixes #156.
