### PR TITLE
Fix for #198 start-polaris throwing error

### DIFF
--- a/Public/Start-Polaris.ps1
+++ b/Public/Start-Polaris.ps1
@@ -74,6 +74,7 @@ function Start-Polaris {
     )
 
     if ( -not $Polaris) {
+        Write-Verbose 'No Polaris found. Creating new.'
         CreateNewPolarisIfNeeded
         $Polaris = $Script:Polaris
     }
@@ -82,6 +83,11 @@ function Start-Polaris {
         Use-PolarisJsonBodyParserMiddleware -Polaris $Polaris
     }
 
+    Write-Verbose "Starting polaris listening"
+    Write-Verbose "   Port: $Port"
+    Write-Verbose "   Https.IsPreset: $($Https.IsPresent)"
+    Write-Verbose "   Auth: $Auth"
+    Write-Verbose "   HostName: $HostName"
     $Polaris.Start( $Port, $Https.IsPresent, $Auth, $HostName)
 
     return $Polaris

--- a/Tests/unit/PolarisServer.Tests.ps1
+++ b/Tests/unit/PolarisServer.Tests.ps1
@@ -7,31 +7,21 @@ Import-Module -Name $PSScriptRoot\..\..\Polaris.psd1
 
 Describe "Test webserver use" {
 
-    BeforeAll {
-
-        $IsUnix = $PSVersionTable.Platform -eq "Unix"
-
-        $Port = Get-Random -Minimum 8000 -Maximum 8999
-
-        # Start the app
-        $Polaris = Start-Polaris -Port $Port -MinRunspaces 1 -MaxRunspaces 5 # all params are optional
-
-    }
-
     Context "Test starting and stopping of the server" {
 
         It "Should allow starting and stopping the server" {
+            $Port = Get-Random -Minimum 8000 -Maximum 8999
+            $Polaris = Start-Polaris -Port $Port
             Stop-Polaris
-            $Polaris = Get-Polaris
             $Polaris.Listener.IsListening | Should Be $false
 
-            $Polaris = Start-Polaris -Port 9998
+            $Polaris = Start-Polaris -Port $Port
             $Polaris.Listener.IsListening | Should be $true
         }
 
         It "Should allow running Start-Polaris multiple times without error" {
-            Stop-Polaris
-            $Polaris = Get-Polaris
+            $Port = Get-Random -Minimum 8000 -Maximum 8999
+            $Polaris = Start-Polaris -Port $Port
             $Polaris.Listener.IsListening | Should Be $false
 
             $Polaris = Start-Polaris -Port 9998

--- a/Tests/unit/PolarisServer.Tests.ps1
+++ b/Tests/unit/PolarisServer.Tests.ps1
@@ -27,5 +27,17 @@ Describe "Test webserver use" {
             $Polaris = Start-Polaris -Port $Port
             $Polaris.Listener.IsListening | Should be $true
         }
+
+        It "Allows a custom logger" {
+            $Port = Get-Random -Minimum 8000 -Maximum 8999
+            $Polaris = Start-Polaris -Port $Port
+            $Polaris.Logger = {
+                param($Word)
+                $Word | Out-File "TestDrive:\test.log" -NoNewline
+            }
+
+            $Polaris.Log("Hello")
+            Get-Content "TestDrive:\test.log" -Raw | Should be "Hello"
+        }
     }
 }

--- a/Tests/unit/PolarisServer.Tests.ps1
+++ b/Tests/unit/PolarisServer.Tests.ps1
@@ -19,26 +19,23 @@ Describe "Test webserver use" {
     }
 
     Context "Test starting and stopping of the server" {
-        BeforeAll {
-            if (-not $IsUnix) {
-                Stop-Polaris
-                $Polaris = Get-Polaris
-                $Polaris.Listener.IsListening | Should Be $false
 
-                $Polaris = Start-Polaris -Port 9998
-                $Polaris.Listener.IsListening | Should be $true
-            }
+        It "Should allow starting and stopping the server" {
+            Stop-Polaris
+            $Polaris = Get-Polaris
+            $Polaris.Listener.IsListening | Should Be $false
+
+            $Polaris = Start-Polaris -Port 9998
+            $Polaris.Listener.IsListening | Should be $true
         }
 
-        It "Allows a custom logger" {
+        It "Should allow running Start-Polaris multiple times without error" {
+            Stop-Polaris
             $Polaris = Get-Polaris
-            $Polaris.Logger = {
-                param($Word)
-                $Word | Out-File "TestDrive:\test.log" -NoNewline
-            }
+            $Polaris.Listener.IsListening | Should Be $false
 
-            $Polaris.Log("Hello")
-            Get-Content "TestDrive:\test.log" -Raw | Should be "Hello"
+            $Polaris = Start-Polaris -Port 9998
+            $Polaris.Listener.IsListening | Should be $true
         }
     }
 }

--- a/Tests/unit/PolarisServer.Tests.ps1
+++ b/Tests/unit/PolarisServer.Tests.ps1
@@ -22,9 +22,9 @@ Describe "Test webserver use" {
         It "Should allow running Start-Polaris multiple times without error" {
             $Port = Get-Random -Minimum 8000 -Maximum 8999
             $Polaris = Start-Polaris -Port $Port
-            $Polaris.Listener.IsListening | Should Be $false
+            $Polaris.Listener.IsListening | Should Be $true
 
-            $Polaris = Start-Polaris -Port 9998
+            $Polaris = Start-Polaris -Port $Port
             $Polaris.Listener.IsListening | Should be $true
         }
     }

--- a/lib/Polaris.Class.ps1
+++ b/lib/Polaris.Class.ps1
@@ -1,4 +1,4 @@
-#
+﻿#
 # Copyright (c) Microsoft. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #
@@ -269,8 +269,21 @@ class Polaris {
         [string]$HostName
     ) {
         $this.StopServer = $false
-        $this.InitListener($Port, $Https, $Auth, $HostName)
-        $this.Listener.BeginGetContext($this.ContextHandler, $this)
+        if($this.Listener -eq $null) {
+            Write-Debug "Creating new listener"
+            $this.InitListener($Port, $Https, $Auth, $HostName)
+            $this.Listener.BeginGetContext($this.ContextHandler, $this)
+        } else {
+            Write-Debug "Listener object already created"
+            if($this.Listener.IsListening){
+                Write-Debug "Listener is already in a listening state. Doing nothing"
+            } else {
+                Write-Debug "Listener object exists but has shut down. Reinitializing..."
+                $this.Stop()
+                $this.InitListener($Port, $Https, $Auth, $HostName)
+                $this.Listener.BeginGetContext($this.ContextHandler, $this)
+            }
+        }
     }
 
     [void] Stop () {
@@ -278,8 +291,8 @@ class Polaris {
         $this.Listener.Close()
         $this.Listener.Dispose()
         $this.Log("Server Stopped.")
-
     }
+
     [void] InitListener (
         [int]$Port,
         [bool]$Https,


### PR DESCRIPTION
I was unable to re-create the issue by running Start-Polaris and Stop-Polaris consecutively but if you happened to run Start-Polaris twice you were out of luck until restarting PowerShell as we were just creating a new instance of HttpListener right over the top of an already listening HttpListener and would throw an error.

@harikanth64 - If possible I'd love it if you could pull this code down and see if it resolves your issue before I merge it in.