### PR TITLE
Update mac Image to 10.14 in CI as 10.13 is going to be deprecated in March

### DIFF
--- a/.vsts-ci/azure-pipelines-ci.yml
+++ b/.vsts-ci/azure-pipelines-ci.yml
@@ -52,7 +52,7 @@ jobs:
 - job: 'PS6_macOS'
   displayName: PowerShell 6 | macOS
   pool:
-    vmImage: 'macOS-10.13'
+    vmImage: 'macOS-10.14'
   steps:
   - template: templates/ci-general.yml
 


### PR DESCRIPTION
# Pull Request Creation Checklist

https://devblogs.microsoft.com/devops/removing-older-images-in-azure-pipelines-hosted-pools/

Note that Azure DevOps recently added 10.15 as well, so an alternative would be to use `macOS-latest` or both images
https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops


-   [x] Useful title (i.e. **Fix #XXX: Description** / **Feature #XXX: Description** / **RFC #XXX: Description**)
-   [x] Description of the changes you are making
-   [ ] Added a link to the related Github issue in the description (i.e. type `Fixes #XXX` in the desciption of the PR)
-   [ ] If you are still working on the code and would like some early feedback via the Pull Request process just add [WIP] to the beginning of your Pull Request title
-   [x] Checked the [Polaris GitHub workflow guidance](/GITHUB_GUIDANCE.md) to make sure my code has the latest changes made to the master branch
-   [ ] Throw small party 🎉
